### PR TITLE
Adds flags to ocm-container.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Related tools added to image:
 ./build.sh
 ```
 
+Build accepts the following flags:
+```
+  -h  --help      Show this message and exit
+  -t  --tag       Build with a specific docker tag
+  -x  --debug     Set the bash debug flag
+```
+
+You can also override the container build flags by separating them at the end of the command with `--`.  Example:
+```
+./build.sh -t local-dev -- --no-cache
+```
+
 ### Use it:
 ```
 ocm-container
@@ -39,9 +51,15 @@ ocm-container
 With launch options:
 ```
 OCM_CONTAINER_LAUNCH_OPTS="-v ~/work/myproject:/root/myproject" ocm-container
+--
+or
+--
+ocm-container -o "-v ~/work/myproject:/root/myproject"
 ```
 
-Launch options provide you a way to add other volumes, add environment variables, or anything else you would need to do to run ocm-container the way you want to.
+Launch options provide you a way to add other volumes, add environment variables, or anything else you would need to do to run ocm-container the way you want to. 
+
+_NOTE_: Using the flag for launch options will then NOT use the environment variable `OCM_CONTAINER_LAUNCH_OPTS`
 
 ## Example:
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,46 @@
 #!/bin/bash
 
+usage() {
+  cat <<EOF
+  usage: $0 [ OPTIONS ] [ -- Additional Docker Options ]
+  Options
+  -h  --help      Show this message and exit
+  -t  --tag       Build with a specific docker tag
+  -x  --debug     Set the bash debug flag
+EOF
+}
+
+BUILD_TAG="latest"
+CONTAINER_ARGS=()
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -h | --help )           usage
+                            exit 1
+                            ;;
+    -t | --tag )            shift
+                            BUILD_TAG=$1
+                            ;;
+    -x | --debug )          set -x
+                            ;;
+
+    -- ) shift
+      CONTAINER_ARGS+=($@)
+      break
+      ;;
+
+    -* ) echo "Unexpected parameter $1"
+        usage
+        exit 1
+        ;;
+
+    * ) echo "Unexpected parameter $1"
+        usage
+        exit 1
+  esac
+  shift
+done
+
 ### cd locally
 cd $(dirname $0)
 
@@ -41,8 +82,8 @@ date -u
 # we want the $@ args here to be re-split
 time ${CONTAINER_SUBSYS}  build \
   --build-arg osv4client=${osv4client} \
-  $@ \
-  -t ocm-container .
+  $CONTAINER_ARGS \
+  -t ocm-container:${BUILD_TAG} .
 
 # for time tracking
 date

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -1,7 +1,52 @@
 #!/bin/bash
 
-### cd locally
-cd $(dirname $0)
+usage() {
+  cat <<EOF
+  usage: $0 [ OPTIONS ] [ Initial Cluster Name ]
+  Options
+  -h  --help          Show this message and exit
+  -o  --launch-opts   Sets extra non-default container launch options
+  -t  --tag           Sets the image tag to use
+  -x  --debug         Set bash debug flag
+
+  Initial Cluster Name can be either the cluster name, cluster id, or external cluster ID.
+EOF
+}
+
+ARGS=()
+BUILD_TAG="latest"
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -h | --help )           usage
+                            exit 1
+                            ;;
+    -o | --launch-opts )    shift
+                            OCM_CONTAINER_LAUNCH_OPTS=$1
+                            ;;
+    -t | --tag )            shift
+                            BUILD_TAG="$1"
+                            ;;
+    -x | --debug )          set -x
+                            ;;
+    -* ) echo "Unexpected parameter $1"
+         usage
+         exit 1
+         ;;
+
+    * ) 
+      ARGS+=($1)
+      ;;
+  esac
+  shift
+done
+
+if [ ${#ARGS[@]} -gt 1 ]
+then
+  echo "Expected at most one argument.  Got ${#ARGS[@]}"
+  usage
+  exit 1
+fi
 
 ### Load config
 CONFIG_DIR=${HOME}/.config/ocm-container
@@ -35,4 +80,4 @@ ${SSH_AGENT_MOUNT} \
 -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro \
 -v ${HOME}/.aws/config:/root/.aws/config:ro \
 ${OCM_CONTAINER_LAUNCH_OPTS} \
-ocm-container /bin/bash 
+ocm-container:${BUILD_TAG} /bin/bash 


### PR DESCRIPTION
Adds build and run flags and their scaffolding to our bash scripts to build and invoke ocm-container.

This changes functionality for `./build.sh` for options like `--no-cache` as they now need to be passed differently in order to pass them separately:

```
previous:
./build.sh --no-cache

new:
./build.sh -- --no-cache
```

WIP: Still needs README updates.