### PR TITLE
allow sudo prompt init

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -44,8 +44,8 @@ else
   init_new_config
 fi
 
-echo "Creating symlink for ocm-container binary"
-ln -sfn "$(pwd)/ocm-container.sh" /usr/local/bin/ocm-container
+echo "Creating symlink for ocm-container binary (requires sudo permissions...)"
+sudo ln -sfn "$(pwd)/ocm-container.sh" /usr/local/bin/ocm-container
 
 echo
 echo "Tip: Many developers like to add the following alias:"


### PR DESCRIPTION
This adds a prompt to input the sudo password when symlinking the ocm-container script into /usr/local/bin.  This allows the rest of the init script itself to be run without sudo privileges, and is more clear about what is and isn't being done as root.
    
Signed-off-by: Christopher Collins <collins.christopher@gmail.com>