### PR TITLE
feat(startup): remove unused variable

### DIFF
--- a/env.source.sample
+++ b/env.source.sample
@@ -13,10 +13,6 @@ export CONTAINER_SUBSYS="sudo docker"
 ### defaults to "ocm"
 export CLI=${CLI:-}
 
-### The toggle to run the ssh-agent inside the container
-### to enale set it to 'ssh-agent'
-export SSH_AUTH_ENABLE=${SSH_AUTH_ENABLE:-}
-
 ### The Url in which you want your ocm queries to go to
 ### you can use 'staging' or 'integration'
 ###

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -35,4 +35,4 @@ ${SSH_AGENT_MOUNT} \
 -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro \
 -v ${HOME}/.aws/config:/root/.aws/config:ro \
 ${OCM_CONTAINER_LAUNCH_OPTS} \
-ocm-container ${SSH_AUTH_ENABLE} /bin/bash 
+ocm-container /bin/bash 


### PR DESCRIPTION
as the macos 'ssh-agent' works without issues,
there is no need for runnig ssh-agent before the command
