### PR TITLE
fix(yum): patch vim installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM fedora:latest
 
 ENV I_AM_IN_CONTAINER="I-am-in-container"
 
-RUN yum -y install \
+# the deletion of 'vim-minimal' is required for package vim-enhanced-2:8.2.2143-1
+# see https://unix.stackexchange.com/a/120226
+RUN yum --assumeyes remove \
+    vim-minimal \ 
+    && yum --assumeyes install \
     bash-completion \
     findutils \
     fzf \
@@ -24,20 +28,20 @@ ADD ./container-setup/install /container-setup/install
 
 WORKDIR /container-setup/install
 
-ARG osv4client=openshift-client-linux-4.3.12.tar.gz
-ARG rosaversion=v0.0.16
 ARG awsclient=awscli-exe-linux-x86_64.zip
 ARG osdctlversion=v0.2.0
+ARG osv4client=openshift-client-linux-4.3.12.tar.gz
+ARG rosaversion=v0.0.16
 ARG veleroversion=v1.5.1
 
-RUN ./install-rosa.sh
-RUN ./install-ocm.sh
-RUN ./install-oc.sh
 RUN ./install-aws.sh
-RUN ./install-kube_ps1.sh
-RUN ./install-osdctl.sh
-RUN ./install-velero.sh
 RUN ./install-cluster-login.sh
+RUN ./install-kube_ps1.sh
+RUN ./install-oc.sh
+RUN ./install-ocm.sh
+RUN ./install-osdctl.sh
+RUN ./install-rosa.sh
+RUN ./install-velero.sh
 
 ADD ./container-setup/utils /container-setup/utils
 WORKDIR /container-setup/utils

--- a/container-setup/utils/bashrc_supplement.sh
+++ b/container-setup/utils/bashrc_supplement.sh
@@ -11,6 +11,9 @@ export KUBE_PS1_SYMBOL_ENABLE=false
 ## Overwrite defaults with user-config
 source /root/.config/ocm-container/env.source
 
+# make vi work as vim does 
+alias vi=vim
+
 complete -C '/usr/local/aws/aws/dist/aws_completer' aws
 
 if [ -n "$INITIAL_CLUSTER_LOGIN" ]


### PR DESCRIPTION
without this change new `./build.sh` commands fail ( cleaned my ocm-container local copy and encountered the issue)

---

seems vim cannot work in tandem with vi anymore.

- sort dockerfile stuff (scripts and env vars)