### PR TITLE
Fix PS1 so that bash new lines work consistently

### DIFF
--- a/container-setup/utils/bashrc_supplement.sh
+++ b/container-setup/utils/bashrc_supplement.sh
@@ -4,7 +4,8 @@ source /usr/local/kube_ps1/kube-ps1.sh
 
 ## Set Defaults
 export EDITOR=vim
-export PS1='[\W $(ocm_environment) $(kube_ps1)]\$ '
+export ENV_OCM_URL=${OCM_URL:-production}
+export PS1="[\W {\[$(tput setaf 2)\]${ENV_OCM_URL}\[$(tput sgr0)\]} $(kube_ps1)]\$ "
 export KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 export KUBE_PS1_SYMBOL_ENABLE=false
@@ -20,10 +21,4 @@ fi
 
 function cluster_function() {
   oc config view  --minify --output 'jsonpath={..server}' | cut -d. -f2-4
-}
-
-function ocm_environment() {
-	# based on how ocm-cli works for now, when the default change we will go with it
-	export ENV_OCM_URL=${OCM_URL:-production}
-	echo "{$(tput setaf 2)${ENV_OCM_URL}$(tput sgr0)}"
 }


### PR DESCRIPTION
This has been bugging me ever since I started using ocm-container.

When you are in a container (bash) session, if your commands are really long, to the point that it extends more than the width of the current line, then bash starts overwriting your current line instead of starting in a new line.

Similar to this issue in [stack overflow](https://unix.stackexchange.com/questions/49891/bash-overwrites-the-first-line-ps1-bash-prompt) .

The fix is to have the colour code to start and end with `\[` and `\]` so that bash does not count that towards the number of characters before it starts a new line.

I tried to fix it with keeping the bash function but in the end this is what I came up with, which works.

Hope this makes sense!