### PR TITLE
If OCM_CONTAINER_KERBEROS_USER is already set, prefer it

### DIFF
--- a/env.source.sample
+++ b/env.source.sample
@@ -23,7 +23,7 @@ export OCM_URL=${OCM_URL:-}
 export OCM_USER=${OCM_USER:-your_user}
 
 ### Your kerberos username (without domain) if different than your OCM_USER
-export OCM_CONTAINER_KERBEROS_USER=${OCM_USER:-$(whoami)}
+export OCM_CONTAINER_KERBEROS_USER=${OCM_CONTAINER_KERBEROS_USER:-${OCM_USER:-$(whoami)}}
 
 ### Your ocm Offline Access Token from
 ###     https://cloud.redhat.com/openshift/token


### PR DESCRIPTION
Prefer `OCM_CONTAINER_KERBEROS_USER` if it is already set in the environment, otherwise fall back to `$OCM_USER` (if set), and then finally fall back to `$(whoami)`

This helps in cases where the Kerberos user is different from the OCM user, for whatever reasons.