### PR TITLE
Use the refresh token directly for ocm login

### DIFF
--- a/container-setup/utils/bin/ocm-login
+++ b/container-setup/utils/bin/ocm-login
@@ -20,15 +20,7 @@ then
   OCM_URL="https://api.openshift.com"
 fi
 
-TOKEN=$(curl \
---silent \
---data-urlencode "grant_type=refresh_token" \
---data-urlencode "client_id=cloud-services" \
---data-urlencode "refresh_token=${OFFLINE_ACCESS_TOKEN}" \
-https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token | \
-jq -r .access_token)
-
-"${CLI}" login --token=$TOKEN ${LOGIN_ENV}=$OCM_URL
+"${CLI}" login --token=$OFFLINE_ACCESS_TOKEN ${LOGIN_ENV}=$OCM_URL
 
 if [ "${CLUSTERID}" != "" ]; then
     oc logout 2>/dev/null


### PR DESCRIPTION
We can use the refresh token to login ocm directly, so that the token won't expire (too soon) for ocm commands.

.ocm.json will look like:
~~~
cat .ocm.json 
{
  "access_token": "<masked>",
  "client_id": "cloud-services",
  "refresh_token": "<masked>",
  "scopes": [
    "openid"
  ],
  "token_url": "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
  "url": "https://api.stage.openshift.com"
}
~~~

And every time we run ocm command, it will refresh the ocm access token automatically if expired.

Or, is there any reason we don't do it that way? Security?