### PR TITLE
Replaces ocm install via go get with release binary

### DIFF
--- a/container-setup/install/install-ocm.sh
+++ b/container-setup/install/install-ocm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -o errexit
+
 if [ "$I_AM_IN_CONTAINER" != "I-am-in-container" ]; then
   echo "must be run in container";
   exit 1;
@@ -8,6 +10,22 @@ fi
 echo "in container";
 source /container-setup/install/helpers.sh
 
-remove_coloring go get -v -u github.com/openshift-online/ocm-cli/cmd/ocm;
-ln -s /root/go/bin/ocm /usr/local/bin/ocm;
+LATEST_RELEASE="https://github.com/openshift-online/ocm-cli/releases/latest/download/ocm-linux-amd64"
+
+mkdir /usr/local/ocm \
+  && pushd /usr/local/ocm
+
+echo "Downloading the latest release"
+curl -sSL ${LATEST_RELEASE} -o ocm-linux-amd64
+echo "Validating binary against SHA256 sum"
+curl -sSL ${LATEST_RELEASE}.sha256 | sha256sum --check --status
+echo "Making binary executable"
+chmod +x ocm-linux-amd64
+echo "Symlinking binary to \"ocm\""
+ln -s /usr/local/ocm/ocm-linux-amd64 /usr/local/bin/ocm
+echo "Checking binary execution"
+ocm version
+
+popd
+
 ocm completion > /etc/bash_completion.d/ocm


### PR DESCRIPTION
As of the creation of this PR, building the container image fails attempting to `go get` ocm-cli. This PR switches the ocm install to use the latest release binary, rather than the current main branch code, akin to using a container image tag rather than `:latest`.