### PR TITLE
[utils] Fixing the overwrite because ENV_OCM_URL is using variable su…

### DIFF
--- a/container-setup/utils/bashrc_supplement.sh
+++ b/container-setup/utils/bashrc_supplement.sh
@@ -2,6 +2,9 @@
 
 source /usr/local/kube_ps1/kube-ps1.sh
 
+## Overwrite defaults with user-config
+source /root/.config/ocm-container/env.source
+
 ## Set Defaults
 export EDITOR=vim
 export ENV_OCM_URL=${OCM_URL:-production}
@@ -9,8 +12,9 @@ export PS1="[\W {\[$(tput setaf 2)\]${ENV_OCM_URL}\[$(tput sgr0)\]} \$(kube_ps1)
 export KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 export KUBE_PS1_SYMBOL_ENABLE=false
+
 ## Overwrite defaults with user-config
-source /root/.config/ocm-container/env.source
+#source /root/.config/ocm-container/env.source
 
 # make vi work as vim does 
 alias vi=vim

--- a/container-setup/utils/bashrc_supplement.sh
+++ b/container-setup/utils/bashrc_supplement.sh
@@ -13,9 +13,6 @@ export KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 export KUBE_PS1_SYMBOL_ENABLE=false
 
-## Overwrite defaults with user-config
-#source /root/.config/ocm-container/env.source
-
 # make vi work as vim does 
 alias vi=vim
 

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -93,7 +93,7 @@ fi
 
 ### start container
 ${CONTAINER_SUBSYS} run -it --rm --privileged \
--e "OCM_URL" \
+-e "OCM_URL=${OCM_URL}" \
 -e "USER" \
 -e "SSH_AUTH_SOCK=/tmp/ssh.sock" \
 -e "KRB5CCNAME=/tmp/krb5cc" \


### PR DESCRIPTION
...bstitution before the overwrite, which does not work because the var OCM_URL has already been defined and substitution only overwrites an undefined or NULL var. Also adding back OCM_URL so that the alias mentioned in the README.md works.