### PR TITLE
Allow OCM_URL to default to production

### DIFF
--- a/container-setup/utils/bashrc_supplement.sh
+++ b/container-setup/utils/bashrc_supplement.sh
@@ -4,8 +4,8 @@ source /usr/local/kube_ps1/kube-ps1.sh
 
 ## Set Defaults
 export EDITOR=vim
-export ENV_OCM_URL=${OCM_URL:-production}
-export PS1="[\W {\[$(tput setaf 2)\]${ENV_OCM_URL}\[$(tput sgr0)\]} \$(kube_ps1)]\$ "
+export OCM_URL=${OCM_URL:-production}
+export PS1="[\W {\[$(tput setaf 2)\]${OCM_URL}\[$(tput sgr0)\]} \$(kube_ps1)]\$ "
 export KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 export KUBE_PS1_SYMBOL_ENABLE=false


### PR DESCRIPTION
This allows OCM_URL to default to production, but allow the prompt to be changed by exporting a new var within the cluster.  Still allows the env var to be overridden in the container as well.