### PR TITLE
Updates velero to be overrideable but set during install

### DIFF
--- a/container-setup/install/install-velero.sh
+++ b/container-setup/install/install-velero.sh
@@ -18,4 +18,5 @@ rm ${velerotarfile};
 mv velero{-${veleroversion}-linux-amd64,};
 ln -s /usr/local/velero/velero /usr/local/bin/velero;
 velero completion bash > /etc/bash_completion.d/velero;
+velero client config set namespace=openshift-velero
 popd;

--- a/container-setup/utils/bashrc_supplement.sh
+++ b/container-setup/utils/bashrc_supplement.sh
@@ -19,7 +19,10 @@ complete -C '/usr/local/aws/aws/dist/aws_completer' aws
 
 ### Set the default namespace for velero to avoid using 
 ### --namespace=openshift-velero each time
-velero client config set namespace=${DEFAULT_VELERO_NS}
+if [ -n "$DEFAULT_VELERO_NS" ]
+then
+  velero client config set namespace=${DEFAULT_VELERO_NS}
+fi
 
 if [ -n "$INITIAL_CLUSTER_LOGIN" ]
 then

--- a/env.source.sample
+++ b/env.source.sample
@@ -26,7 +26,8 @@ export OCM_USER=${OCM_USER:-your_user}
 export OCM_CONTAINER_KERBEROS_USER=${OCM_CONTAINER_KERBEROS_USER:-${OCM_USER:-$(whoami)}}
 
 ### Default namespace for velero
-export DEFAULT_VELERO_NS=${DEFAULT_VELERO_NS:-openshift-velero}
+# set this if you want to change the default velero namespace in container.
+# export DEFAULT_VELERO_NS=openshift-velero
 
 ### Your ocm Offline Access Token from
 ###     https://cloud.redhat.com/openshift/token


### PR DESCRIPTION
From @karthikperu7's PR yesterday I built off of that and the feedback that @drewandersonnz had to initialize velero with a sane default, but check on container initialization to see if the env is overridden and then reconfigure velero from there.