### PR TITLE
Adjust `sre-login` to allow arguments  [WAS: Fixes sre-login to use OCM_USER var]

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Welcome! See 'oc help' to get started.
 ```
 
 ### Automatic Login
-We've built in functionality to simplify the cluster login steps.  Now within the contianer you can run `sre-login cluster-id` and it will refresh your ocm login, create a tunnel within the container if necessary, and then log-in to the cluster.
+We've built in functionality to simplify the cluster login steps.  Now within the contianer you can run `sre-login -c cluster-id` and it will refresh your ocm login, create a tunnel within the container if necessary, and then log-in to the cluster.
 
 `sre-login` accepts both a cluster-name or a cluster-id.  If the cluster-name is not unique, it will not ask which one, but display the clusters and exit.
 

--- a/container-setup/utils/bashrc_supplement.sh
+++ b/container-setup/utils/bashrc_supplement.sh
@@ -26,7 +26,7 @@ fi
 
 if [ -n "$INITIAL_CLUSTER_LOGIN" ]
 then
-  sre-login $INITIAL_CLUSTER_LOGIN
+  sre-login -c $INITIAL_CLUSTER_LOGIN
 fi
 
 function cluster_function() {

--- a/container-setup/utils/bin/sre-login
+++ b/container-setup/utils/bin/sre-login
@@ -65,4 +65,9 @@ then
 fi
 
 # Login to the Cluster
-cluster-login -c "$cluster_id"
+if [[ -z $OCM_USER ]]
+then
+  cluster-login -c "$cluster_id"
+else
+  cluster-login -c "$cluster_id" -e ${OCM_USER}@redhat.com
+fi

--- a/container-setup/utils/bin/sre-login
+++ b/container-setup/utils/bin/sre-login
@@ -1,18 +1,71 @@
 #!/bin/bash -e
 
-if [ -z $1 ]
-then
-  echo "First parameter must be a cluster"
+f_help() {
+  echo "usage: sre-login [-h] [-d] -c CLUSTER [-i OCM_IDENTITY]" 
+  echo ""
+  echo "required arguments:"
+  echo "  -c      the name or ID of the cluster to log into"
+  echo ""
+  echo "optional arguments:"
+  echo "  -h      show this help message and exit"
+  echo "  -d      debug (bash xtrace)"
+  echo "  -i      OCM Identity to use for cluster login (usually your Kerberos ID; can be set as an ENV VAR)"
+}
+
+unset CLUSTER
+
+# Array to hold login arguments for cluster-login script
+CLUSTER_LOGIN_ARGS=()
+
+while getopts ":hdi:c:" opt ; do
+  case ${opt} in
+    h )
+      f_help
+      exit 0
+      ;;
+    i )
+      OCM_IDENTITY=${OPTARG}
+      ;;
+    c )
+      CLUSTER=${OPTARG}
+      ;;
+    d )
+      # Debug
+      set -o xtrace
+      ;;
+    \? )
+      echo "Invalid option: ${OPTARG}" 1>&2
+      f_help
+      exit 1
+      ;;
+    : )
+      echo "Invalid options: ${OPTARG} requires and argument" 1>&2
+      f_help
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+if [ ${OPTIND} -eq 1 ] ; then
+  echo "Cluster name or ID is required"
+  f_help
   exit 1
+fi
+
+# Login to the Cluster
+if [[ ! -z $OCM_IDENTITY ]]
+then
+  CLUSTER_LOGIN_ARGS+=("-e ${OCM_IDENTITY}")
 fi
 
 # Login to OCM first
 ocm-login > /dev/null
 
-echo "Logging into cluster $1"
+echo "Logging into cluster ${CLUSTER}"
 
 function get_cluster_json {
-  ocmjson=$(ocm get clusters --parameter search="name='$1'")
+  ocmjson=$(ocm get clusters --parameter search="name='${CLUSTER}'")
 
   ## ensure we only get one cluster with the name provided
   if [ $(jq -r ".total" <<< $ocmjson) -eq 1 ]
@@ -29,7 +82,7 @@ function get_cluster_json {
   fi
 
   ## If we get here, assume there were no results for name and try ID
-  ocmjson=$(ocm get clusters --parameter search="id='$1'")
+  ocmjson=$(ocm get clusters --parameter search="id='${CLUSTER}'")
   if [ $(jq -r ".total" <<< $ocmjson) -eq 1 ]
   then
     echo $(jq ".items[0]" <<< $ocmjson)
@@ -37,23 +90,24 @@ function get_cluster_json {
   fi
 
   ### If we get here, try external ID
-  ocmjson=$(ocm get clusters --parameter search="external_id='$1'")
+  ocmjson=$(ocm get clusters --parameter search="external_id='${CLUSTER}'")
   if [ $(jq -r ".total" <<< $ocmjson) -eq 1 ]
   then
     echo $(jq ".items[0]" <<< $ocmjson)
     return
   fi
 
-  echo "Could not find a cluster with name, id or external id of \"$1\"" >&2
+  echo "Could not find a cluster with name, id or external id of \"${CLUSTER}\"" >&2
   exit 1
 }
 
 # Check if we need to create a tunnel and save the ID
-clusterjson=$(get_cluster_json $1)
+clusterjson=$(get_cluster_json ${CLUSTER})
 cluster_id=$(jq -r '.id' <<< "$clusterjson")
 cluster_listening=$(jq -r '.api.listening' <<< "$clusterjson")
 
 echo "Cluster ID: $cluster_id"
+CLUSTER_LOGIN_ARGS+=("-c ${cluster_id}")
 
 # Initialize Tunnel if needed
 if [ $cluster_listening == "internal" ]
@@ -64,10 +118,5 @@ then
   echo "Logging In..."
 fi
 
-# Login to the Cluster
-if [[ -z $OCM_USER ]]
-then
-  cluster-login -c "$cluster_id"
-else
-  cluster-login -c "$cluster_id" -e ${OCM_USER}@redhat.com
-fi
+echo "cluster-login ${CLUSTER_LOGIN_ARGS[*]}"
+cluster-login ${CLUSTER_LOGIN_ARGS[*]}

--- a/env.source.sample
+++ b/env.source.sample
@@ -25,6 +25,10 @@ export OCM_USER=${OCM_USER:-your_user}
 ### Your kerberos username (without domain) if different than your OCM_USER
 export OCM_CONTAINER_KERBEROS_USER=${OCM_CONTAINER_KERBEROS_USER:-${OCM_USER:-$(whoami)}}
 
+### Set identity to be used for sre-login; eg "user@example.org"
+### This can be used to override other auth credentials if needed
+# export OCM_IDENTITY="user@example.org"
+
 ### Default namespace for velero
 # set this if you want to change the default velero namespace in container.
 # export DEFAULT_VELERO_NS=openshift-velero


### PR DESCRIPTION
Currently, the `sre-login` script ignores if the `$OCM_USER` variable is set.  This change adjusts the sre-login script to accept multiple arguments:

    usage: sre-login [-h] [-d] -c CLUSTER [-i OCM_IDENTITY]

    required arguments:
      -c      the name or ID of the cluster to log into

    optional arguments:
      -h      show this help message and exit
      -d      debug (bash xtrace)
      -i      OCM Identity to use for cluster login (usually your Kerberos ID)


The added help message and debug will assist new users or folks having issues tracking down where their login problems are occuring, and the OCM identiy argument will allow setting of any ID needed to login to the cluster.

`OCM_IDENTITY` can also be set via ENV VAR, so it doesn't need to be specified manually.

This also sets the stage to add other arguments if necessary, both for use in this script or as options passed to `cluster-login`.

This comes at the expense of needed to pass `-c cluster` rather than just the bare cluster name, but I think this is more clear usage, and less prone to issues.

I'm happy to adjust to accept the old usage as well, or to add a deprecation message, if that's desired.

~~Currently, the `sre-login` script ignores if the `$OCM_USER` variable is set.  This change modifies the script to pass the `-e ${OCM_USER}@redhat.com` flag when calling `cluster-login` if the `$OCM_USER` variable is set.~~

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>