### PR TITLE
Add tmux to ocm-container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN yum --assumeyes remove \
     python3-requests-kerberos \
     rsync \
     sshuttle \
+    tmux \
     vim-enhanced \
     wget \
     && yum clean all;


### PR DESCRIPTION
Add tmux to ocm-container

This PR adds the `tmux` package to ocm-container. This is useful for
tailing container logs while making changes to configurations.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>