### PR TITLE
Adds utility to list available scripts in ocm-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Related tools added to image:
 * Displays current cluster-name, and OpenShift project (`oc project`) in bash PS1
 * Ability to login to private clusters without using a browser
 
+OCM Container also includes multiple scripts for your ease of use. For a quick overview of what is available, run `list-utils`.
+
 ## Quick Start:
 
 * clone this repo

--- a/container-setup/utils/bin/cluster-login
+++ b/container-setup/utils/bin/cluster-login
@@ -1,10 +1,11 @@
 #!/usr/bin/python3
-#
 # Pulled from https://github.com/mbarnes/work-environment/blob/master/files/bin/srelogin
 #
 # Logs into an OpenShift Dedicated v4 cluster via the
 # "OpenShift_SRE" identity provider. Requires a valid
 # Kerberos ticket for production clusters.
+#
+# OCM_CONTAINER_DOC: Logs into an OpenShift Dedicated v4 cluster via the "OpenShift_SRE IDP"
 #
 # Setup instructions:
 #

--- a/container-setup/utils/bin/create-cluster
+++ b/container-setup/utils/bin/create-cluster
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# OCM_CONTAINER_DOC: Create a cluster with a generated name and optionally specify a cluster version
 
 import argparse
 import json

--- a/container-setup/utils/bin/elevate.sh
+++ b/container-setup/utils/bin/elevate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# OCM_CONTAINER_DOC: Adds the current user to the osd-sre-cluster-admins group
 
 ### This script is a temporary change until the group is changed
 ### But it will allow you to preform cluster admin operations

--- a/container-setup/utils/bin/list-utils
+++ b/container-setup/utils/bin/list-utils
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# OCM_CONTAINER_DOC: Lists available helper scripts and utilities in ocm-container
+
+UTIL_DIR="/root/utils"
+
+if [ "$I_AM_IN_CONTAINER" != "I-am-in-container" ]; then
+    UTIL_DIR="./container-setup/utils/bin/"
+fi
+
+# If no argument is provided, will list entire dir
+for i in $(ls ${UTIL_DIR}/${1} | sort) ; do
+	DOC=$(awk -F:  '/^# OCM_CONTAINER_DOC/ {print $2}' ${UTIL_DIR}/${i})
+	echo -e "${i},${DOC}"
+done | column -s ',' -t
+

--- a/container-setup/utils/bin/login.sh
+++ b/container-setup/utils/bin/login.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# OCM_CONTAINER_DOC: Wrapper for `ocm-login` script
 
 echo "login.sh is being deprecated in favor of the command 'ocm-login'"
 ocm-login

--- a/container-setup/utils/bin/ocm-login
+++ b/container-setup/utils/bin/ocm-login
@@ -1,4 +1,5 @@
 #!/bin/bash
+# OCM_CONTAINER_DOC: Logs into OCM and optionally directly into a cluster
 
 CLUSTERID=$1
 

--- a/container-setup/utils/bin/sre-login
+++ b/container-setup/utils/bin/sre-login
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+# OCM_CONTAINER_DOC: Logs into a cluster via the command line
 
 if [ -z $1 ]
 then


### PR DESCRIPTION
Adds a script utility `list-utils` that will list extra utils installed
in ocm-contianer, and print a description of what they do.

The description is pulled from a comment in the individual script
formatted as: `# OCM_CONTAINER_DOC: <description>`

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
