### PR TITLE
pause hive sync

### DIFF
--- a/container-setup/utils/bin/cluster-login
+++ b/container-setup/utils/bin/cluster-login
@@ -1,10 +1,11 @@
 #!/usr/bin/python3
-#
 # Pulled from https://github.com/mbarnes/work-environment/blob/master/files/bin/srelogin
 #
 # Logs into an OpenShift Dedicated v4 cluster via the
 # "OpenShift_SRE" identity provider. Requires a valid
 # Kerberos ticket for production clusters.
+#
+# OCM_CONTAINER_DOC: Logs into an OpenShift Dedicated v4 cluster via the "OpenShift_SRE IDP"
 #
 # Setup instructions:
 #

--- a/container-setup/utils/bin/create-cluster
+++ b/container-setup/utils/bin/create-cluster
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# OCM_CONTAINER_DOC: Create a cluster with a generated name and optionally specify a cluster version
 
 import argparse
 import json

--- a/container-setup/utils/bin/elevate.sh
+++ b/container-setup/utils/bin/elevate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# OCM_CONTAINER_DOC: Adds the current user to the osd-sre-cluster-admins group
 
 ### This script is a temporary change until the group is changed
 ### But it will allow you to preform cluster admin operations

--- a/container-setup/utils/bin/list-utils
+++ b/container-setup/utils/bin/list-utils
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# OCM_CONTAINER_DOC: Lists available helper scripts and utilities in ocm-container
+
+UTIL_DIR="/root/utils"
+
+if [ "$I_AM_IN_CONTAINER" != "I-am-in-container" ]; then
+    UTIL_DIR="./container-setup/utils/bin/"
+fi
+
+# If no argument is provided, will list entire dir
+for i in $(ls ${UTIL_DIR}/${1} | sort) ; do
+	DOC=$(awk -F:  '/^# OCM_CONTAINER_DOC/ {print $2}' ${UTIL_DIR}/${i})
+	echo -e "${i},${DOC}"
+done | column -s ',' -t
+

--- a/container-setup/utils/bin/login.sh
+++ b/container-setup/utils/bin/login.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# OCM_CONTAINER_DOC: Wrapper for `ocm-login` script
 
 echo "login.sh is being deprecated in favor of the command 'ocm-login'"
 ocm-login

--- a/container-setup/utils/bin/ocm-login
+++ b/container-setup/utils/bin/ocm-login
@@ -1,4 +1,5 @@
 #!/bin/bash
+# OCM_CONTAINER_DOC: Logs into OCM and optionally directly into a cluster
 
 CLUSTERID=$1
 

--- a/container-setup/utils/bin/pause-hive-sync
+++ b/container-setup/utils/bin/pause-hive-sync
@@ -33,7 +33,6 @@ while getopts ":hc:" opt; do
 done
 
 # Correct argument provided
-
 if test -z ${CLUSTER_DEPLOYMENT} ; then
   _fail_exit "No cluster name provided"
 fi

--- a/container-setup/utils/bin/pause-hive-sync
+++ b/container-setup/utils/bin/pause-hive-sync
@@ -6,7 +6,7 @@ ANNOTATION='hive.openshift.io/syncset-pause="true"'
 
 # _help provides standard help message for the script
 _help(){
-        echo -e "Usage: $(basename ${0}) -c CLUSTER_NAME\n"
+        echo "Usage: $(basename ${0}) -c CLUSTER_NAME"
         echo "Pause hive sync to a cluster (adds \"syncset-pause\" annotation)"
 }
 

--- a/container-setup/utils/bin/pause-hive-sync
+++ b/container-setup/utils/bin/pause-hive-sync
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# OCM_CONTAINER_DOC: Adds the hive syncset-pause annotation to a cluster deployment
+
+# Annotation to pause sync
+ANNOTATION="hive.openshift.io/syncset-pause=\"true\""
+
+# _help provides standard help message for the script
+_help(){
+        echo -e "Usage: $(basename ${0}) -c CLUSTER_NAME\n"
+        echo "Pause hive sync to a cluster (adds \"syncset-pause\" annotation)"
+}
+
+# _fail_exit prints an error message with newline, and then exits with code 1
+_fail_exit(){
+  message="${1}"
+
+  echo -e "${message}\n"
+  exit 1
+}
+
+# Cluster deployment must be provided
+while getopts ":hc:" opt; do
+  case ${opt} in
+    h ) _help
+      ;;
+    c ) CLUSTER_DEPLOYMENT=${OPTARG}
+      ;;
+    : ) echo "Invalid option: ${OPTARG} requires an argument" 1>&2
+      ;;
+    \? ) echo "Invalid option: ${OPTARG}" 1>&2 ; _help
+      ;;
+  esac
+done
+
+# Correct argument provided
+
+if test -z ${CLUSTER_DEPLOYMENT} ; then
+  _fail_exit "No cluster name provided"
+fi
+
+# Logged into hive?
+if ! oc whoami > /dev/null ; then
+  _fail_exit "Must login to the hive cluster first"
+fi
+
+# Get clusterDeployment
+CLUSTER_DEPLOYMENT_NAMESPACE="$(oc get clusterdeployment --all-namespaces --selector api.openshift.com/name=${CLUSTER_DEPLOYMENT} --output template --template='{{range .items}}{{.metadata.namespace}}{{end}}')"
+
+if [[ "${CLUSTER_DEPLOYMENT_NAMESPACE}" == "" ]] ; then
+        _fail_exit "Something failed retrieving the clusterdeployment: \"oc get clusterdeployment --all-namespaces | grep ${CLUSTER_DEPLOYMENT}\""
+fi
+
+# Add the annotation to pause sync
+oc annotate clusterdeployment ${CLUSTER_DEPLOYMENT} -n ${CLUSTER_DEPLOYMENT_NAMESPACE} ${ANNOTATION}  || _fail_exit "Something failed attempting to annotate clusterdeployment: \"oc annotate clusterdeployment ${CLUSTER_DEPLOYMENT} -n ${CLUSTER_DEPLOYMENT_NAMESPACE} ${ANNOTATION}\""

--- a/container-setup/utils/bin/pause-hive-sync
+++ b/container-setup/utils/bin/pause-hive-sync
@@ -2,45 +2,67 @@
 # OCM_CONTAINER_DOC: Adds the hive syncset-pause annotation to a cluster deployment
 
 # Annotation to pause sync
-ANNOTATION='hive.openshift.io/syncset-pause="true"'
+ANNOTATION='hive.openshift.io/syncset-pause'
 
 # _help provides standard help message for the script
 _help(){
-        echo "Usage: $(basename ${0}) -c CLUSTER_NAME"
+        echo "Usage: $(basename ${0}) -c CLUSTER_NAME -s (on|off)"
         echo "Pause hive sync to a cluster (adds \"syncset-pause\" annotation)"
+        echo ""
 }
 
 # _fail_exit prints an error message with newline, and then exits with code 1
 _fail_exit(){
   message="${1}"
 
-  echo -e "${message}\n"
+  echo -e "${message}\n" 2>&1
   exit 1
 }
 
+_logged_in(){
+  # Logged into hive?
+  if ! oc whoami > /dev/null ; then
+    _help
+    _fail_exit "Must login to the hive cluster first"
+  fi
+}
+
 # Cluster deployment must be provided
-while getopts ":hc:" opt; do
+while getopts ":hlc:s:" opt; do
   case ${opt} in
-    h ) _help
+    h ) _help ; exit 0
       ;;
     c ) CLUSTER_DEPLOYMENT=${OPTARG}
       ;;
-    : ) echo "Invalid option: ${OPTARG} requires an argument" 1>&2
+    l ) LIST="true"
       ;;
-    \? ) echo "Invalid option: ${OPTARG}" 1>&2 ; _help
+    s ) PAUSE_STATE=${OPTARG}
+      ;;
+    : ) _help ; _fail_exit "Invalid option: ${OPTARG} requires an argument"
+      ;;
+    \? ) _help ; _fail_exit "Invalid option: ${OPTARG}"
       ;;
   esac
 done
 
-# Correct argument provided
+# Correct arguments provided
 if test -z ${CLUSTER_DEPLOYMENT} ; then
+  _help
   _fail_exit "No cluster name provided"
 fi
 
-# Logged into hive?
-if ! oc whoami > /dev/null ; then
-  _fail_exit "Must login to the hive cluster first"
+if test -z ${PAUSE_STATE}; then
+  _help
+  _fail_exit "No pause state provided"
 fi
+
+if [[ ${PAUSE_STATE} != "on" && ${PAUSE_STATE} != "off" ]]; then
+  _help
+  _fail_exit "No valid pause state provided, must be 'on' or 'off'"
+fi
+
+# Logged into hive?
+_logged_in
 
 # Get clusterDeployment
 CLUSTER_DEPLOYMENT_NAMESPACE="$(oc get clusterdeployment --all-namespaces --selector api.openshift.com/name=${CLUSTER_DEPLOYMENT} --output template --template='{{range .items}}{{.metadata.namespace}}{{end}}')"
@@ -50,4 +72,9 @@ if [[ "${CLUSTER_DEPLOYMENT_NAMESPACE}" == "" ]] ; then
 fi
 
 # Add the annotation to pause sync
-oc annotate clusterdeployment ${CLUSTER_DEPLOYMENT} -n ${CLUSTER_DEPLOYMENT_NAMESPACE} ${ANNOTATION}  || _fail_exit "Something failed attempting to annotate clusterdeployment: \"oc annotate clusterdeployment ${CLUSTER_DEPLOYMENT} -n ${CLUSTER_DEPLOYMENT_NAMESPACE} ${ANNOTATION}\""
+if [[ ${PAUSE_STATE} == "on" ]]; then
+        oc annotate clusterdeployment ${CLUSTER_DEPLOYMENT} -n ${CLUSTER_DEPLOYMENT_NAMESPACE} ${ANNOTATION}="true"  || _fail_exit "Something failed attempting to annotate clusterdeployment: \"oc annotate clusterdeployment ${CLUSTER_DEPLOYMENT} -n ${CLUSTER_DEPLOYMENT_NAMESPACE} ${ANNOTATION}=\"true\"\""
+else
+        oc annotate clusterdeployment ${CLUSTER_DEPLOYMENT} -n ${CLUSTER_DEPLOYMENT_NAMESPACE} ${ANNOTATION}-  || _fail_exit "Something failed attempting to annotate clusterdeployment: \"oc annotate clusterdeployment ${CLUSTER_DEPLOYMENT} -n ${CLUSTER_DEPLOYMENT_NAMESPACE} ${ANNOTATION}-\""
+fi
+

--- a/container-setup/utils/bin/pause-hive-sync
+++ b/container-setup/utils/bin/pause-hive-sync
@@ -2,7 +2,7 @@
 # OCM_CONTAINER_DOC: Adds the hive syncset-pause annotation to a cluster deployment
 
 # Annotation to pause sync
-ANNOTATION="hive.openshift.io/syncset-pause=\"true\""
+ANNOTATION='hive.openshift.io/syncset-pause="true"'
 
 # _help provides standard help message for the script
 _help(){

--- a/container-setup/utils/bin/sre-login
+++ b/container-setup/utils/bin/sre-login
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+# OCM_CONTAINER_DOC: Logs into a cluster via the command line
 
 if [ -z $1 ]
 then


### PR DESCRIPTION
Adds script to pause hive sync

Adds a script to pause hive sync for a cluster. Must be logged into the
hive that controls the cluster you wish to pause syncing on.

Usage: `pause-hive-sync -c CLUSTER_NAME`

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
