### PR TITLE
Remove the vim-minimal workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,7 @@ FROM fedora:latest
 
 ENV I_AM_IN_CONTAINER="I-am-in-container"
 
-# the deletion of 'vim-minimal' is required for package vim-enhanced-2:8.2.2143-1
-# see https://unix.stackexchange.com/a/120226
-RUN yum --assumeyes remove \
-    vim-minimal \ 
-    && yum --assumeyes install \
+RUN yum --assumeyes install \
     bash-completion \
     findutils \
     fzf \


### PR DESCRIPTION
This appears to no longer be necessary.  Tested on a F33 Laptop with
latest pulled image from `fedora:latest`.

If others no longer have the issue, this will remove some extra time
from the build process.

REF: https://unix.stackexchange.com/questions/119310/transaction-check-error-in-installing-vim/120226#120226

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
