### PR TITLE
Add krb5-workstation package for kerb error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN yum --assumeyes remove \
     git \
     golang \
     jq \
+    krb5-workstation \
     make \
     openssl \
     procps-ng \


### PR DESCRIPTION
Currently the cluster-login script expects kinit and klist to exist in
order to handle some kinit errors correctly. This adds the
krb5-workstation package for those files, which allows cluster-login to
print helpful error messages regarding kinit status.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
