### PR TITLE
Replaces tooling ENV with build ARGS; improves help for build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,16 @@
 
 usage() {
   cat <<EOF
-  usage: $0 [ OPTIONS ] [ -- Additional Docker Options ]
+  usage: $0 [ OPTIONS ] [ -- Additional Docker Build Options ]
   Options
   -h  --help      Show this message and exit
   -t  --tag       Build with a specific docker tag
   -x  --debug     Set the bash debug flag
+
+  Example:
+
+  $0 --tag devel -- "--build-arg=OSDCTL_VERSION=tags/v0.4.0 --build-arg=ROSA_VERSION=v1.0"
+
 EOF
 }
 


### PR DESCRIPTION
Replaces use of ENV arguments for tooling version with build ARGS in the
Dockerfile.

Improves the help message for `build.sh` to show an example of passing
build args to the container build, particularly multiple build args.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
