### PR TITLE
add fzf bash history search for Ctrl-R

### DIFF
--- a/utils/bashrc.d/fzf.bashrc
+++ b/utils/bashrc.d/fzf.bashrc
@@ -1,0 +1,2 @@
+# FZF mappings and options
+[ -f /usr/share/fzf/shell/key-bindings.bash ] && source /usr/share/fzf/shell/key-bindings.bash


### PR DESCRIPTION
fzf is already installed, this enables it to take over bash history search

how to use: 
bash$ Ctrl-R 
fzf activates with .bash_history
type your fzf, same as you would for reverse-i-search
press enter when you find the command you want
command is pasted for you to edit, or to action