### PR TITLE
Install o-must-gather to easily browse must gathers inside ocm-container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,8 +177,8 @@ ENV PATH "$PATH:/root/.local/bin"
 # Install utils
 COPY utils/bin /root/.local/bin
 
-# Setup requirements for cluster-login.sh
-RUN pip3 install requests-html && pyppeteer-install
+# Setup requirements for cluster-login.sh and install o-must-gather
+RUN pip3 install requests-html o-must-gather && pyppeteer-install
 
 # Setup bashrc.d directory
 # Files with a ".bashrc" extension are sourced on login


### PR DESCRIPTION
Installing https://github.com/kxr/o-must-gather in ocm-container.

Especially useful when debugging must gathers from hive for [clusterprovDelays/failures](https://github.com/openshift/hive-sops/blob/master/sop/ClusterProvisioningFailure.md#troubleshoot-using-the-clusters-must-gather). 

This barely added to the total size of the image. Stayed at `1.73GB` before and after adding `omg`.