### PR TITLE
Adds PagerDuty CLI support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN yum --assumeyes install \
     golang \
     jq \
     krb5-workstation \
-    make \
+    npm \
     openssl \
     procps-ng \
     python-pip \
@@ -119,7 +119,6 @@ RUN /bin/bash -c "curl -sSLf -O $(curl -sSLf ${VELERO_URL} -o - | jq -r '.assets
 RUN sha256sum --check --ignore-missing sha256sum.txt
 RUN tar --extract --gunzip --no-same-owner --directory /out --wildcards --no-wildcards-match-slash --no-anchored --strip-components=1 *velero --file *.tar.gz
 
-
 # Install aws-cli
 RUN mkdir -p /aws/bin
 WORKDIR /aws
@@ -153,7 +152,7 @@ COPY --from=builder /out/rosa ${BIN_DIR}
 COPY --from=builder /out/osdctl ${BIN_DIR}
 COPY --from=builder /out/ocm ${BIN_DIR}
 COPY --from=builder /out/velero ${BIN_DIR}
-COPY --from=builder /aws/bin/ ${BIN_DIR}/
+COPY --from=builder /aws/bin/ ${BIN_DIR}
 COPY --from=builder /usr/local/aws-cli /usr/local/aws-cli
 
 # Validate
@@ -173,6 +172,9 @@ COPY utils/bin /root/.local/bin
 
 # Setup requirements for cluster-login.sh and install o-must-gather
 RUN pip3 install requests-html o-must-gather && pyppeteer-install
+
+# Setup pagerduty-cli
+RUN npm install -g pagerduty-cli@0.0.70
 
 # Setup bashrc.d directory
 # Files with a ".bashrc" extension are sourced on login

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ OCM Container also includes multiple scripts for your ease of use. For a quick o
   * set your requested OCM_USER (for `ocm -u OCM_USER`)
   * set your OFFLINE_ACCESS_TOKEN (from [cloud.redhat.com](https://cloud.redhat.com/))
   * set your kerberos username if it's different than your OCM_USER
+* optional: add your PagerDuty API token in `~/.config/pagerduty-cli/config.json`
 * optional: configure alias in `~/.bashrc`
   * alias ocm-container-stg="OCM_URL=stg ocm-container"
   * alias ocm-container-local='OCM_CONTAINER_LAUNCH_OPTS="-v $(pwd):/root/local" ocm-container'

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -77,6 +77,13 @@ then
   SSH_AGENT_MOUNT="--mount type=bind,src=/run/host-services/ssh-auth.sock,target=/tmp/ssh.sock,readonly"
 fi
 
+### PagerDuty Token Mounting
+PAGERDUTY_TOKEN_FILE=".config/pagerduty-cli/config.json"
+if [ -f ${HOME}/${PAGERDUTY_TOKEN_FILE} ]
+then
+  PAGERDUTYFILEMOUNT="-v ${HOME}/${PAGERDUTY_TOKEN_FILE}:/root/${PAGERDUTY_TOKEN_FILE}:ro"
+fi
+
 ### Kerberos Ticket Mounting
 OCM_CONTAINER_KRB5CC_FILE=${KRB5CCNAME:-/tmp/krb5cc_$UID}
 OCM_CONTAINER_KRB5CC_FILE=${OCM_CONTAINER_KRB5CC_FILE//FILE:}
@@ -115,6 +122,7 @@ ${INITIAL_CLUSTER_LOGIN} \
 -v ${HOME}/.ssh:/root/.ssh:ro \
 -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro \
 -v ${HOME}/.aws/config:/root/.aws/config:ro \
+${PAGERDUTYFILEMOUNT} \
 ${KRB5CCFILEMOUNT} \
 ${SSH_AGENT_MOUNT} \
 ${OCM_CONTAINER_LAUNCH_OPTS} \


### PR DESCRIPTION
~Installs `go-pagerduty` [https://github.com/PagerDuty/go-pagerduty](https://github.com/PagerDuty/go-pagerduty), and adds the necessary mount for the authentication token.~

Installs `pagerduty-cli` [https://github.com/martindstone/pagerduty-cli](https://github.com/martindstone/pagerduty-cli), and adds the necessary mount for the authentication token.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
