### PR TITLE
fix(kube-ps1): replace tput

### DIFF
--- a/utils/bashrc.d/04-kube-ps1.bashrc
+++ b/utils/bashrc.d/04-kube-ps1.bashrc
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 source ${HOME}/.bashrc.d/05-kube-ps1.sh
 
-export PS1="[\W {\[$(tput setaf 2)\]${OCM_URL}\[$(tput sgr0)\]} \$(kube_ps1)]\$ "
+export PS1="[\W {\e[32m${OCM_URL}\e[39m} \$(kube_ps1)]\$ "
 export KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 export KUBE_PS1_SYMBOL_ENABLE=false


### PR DESCRIPTION
during old fix, tput has been removed
now I use native commands instead of tput
