### PR TITLE
Re-adds `git` and `golang` packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN yum --assumeyes install \
     bash-completion \
     findutils \
     fzf \
+    git \
+    golang \
     jq \
     npm \
     make \


### PR DESCRIPTION
Re-adds the `git` and `golang` RPMs.  They are required for backplane install.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
