### PR TITLE
Fixes bash prompt

### DIFF
--- a/utils/bashrc.d/04-kube-ps1.bashrc
+++ b/utils/bashrc.d/04-kube-ps1.bashrc
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 source ${HOME}/.bashrc.d/05-kube-ps1.sh
 
-export PS1="[\W {\e[32m${OCM_URL}\e[39m} \$(kube_ps1)]\$ "
+export PS1="[\W {\[\033[1;32m\]${OCM_URL}\[\033[0m\]} \$(kube_ps1)]\$ "
 export KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 export KUBE_PS1_SYMBOL_ENABLE=false


### PR DESCRIPTION
There was an issue possibly introduced in #62 caused by non-printing characters that is causing the prompt to be unaware of it's length.  This is causing pasted or lines scrolled through the history to have inconsistent placement and unpredictable behavior.

 This fix should keep the same prompt layout and colors, but fix the non-printing character issue.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
