### PR TITLE
Fixes chgm script erronious exit

### DIFF
--- a/utils/bin/chgm
+++ b/utils/bin/chgm
@@ -55,7 +55,12 @@ shift $((OPTIND -1))
 # Check required commands are in $PATH
 for cmd in "${REQUIRED_COMMANDS[@]}"
 do
-  command -v $cmd > /dev/null || echo -e "Command $cmd is required for this script to work.\n" ; usage ; exit 1
+  if ! command -v $cmd > /dev/null
+  then
+    echo -e "Command $cmd is required for this script to work.\n"
+    usage
+    exit 1
+   fi
 done
 
 PD_ALERT="${1}"


### PR DESCRIPTION
The chgm script has an error causing it to stop execution before parsing
the pager duty alert. This was introduced accidentally when removing a
string of checks from a subshell for better processing.

This changes to an if-statement test to work as intended.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
