### PR TITLE
georgettica/make initial ux cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@
 A quick environment for accessing OpenShift v4 clusters. Nothing fancy, gets the job done.
 
 Related tools added to image:
-* `ocm`
-* `oc`
 * `aws`
+* `oc`
+* `ocm`
+* `omg` 
 * `osdctl`
+* `pd`
+* `rosa`
+* `velero`
+* `yq`
 
 ## Features:
 * Does not mount any host filesystem objects as read/write, only uses read-only mounts.
@@ -27,7 +32,7 @@ Related tools added to image:
 
 OCM Container also includes multiple scripts for your ease of use. For a quick overview of what is available, run `list-utils`.
 
-## Quick Start:
+## Installation:
 
 * clone this repo
 * `./init.sh`
@@ -35,7 +40,7 @@ OCM Container also includes multiple scripts for your ease of use. For a quick o
 * edit the file `$HOME/.config/ocm-container/env.source`
   * set your requested OCM_USER (for `ocm -u OCM_USER`)
   * set your OFFLINE_ACCESS_TOKEN (from [cloud.redhat.com](https://cloud.redhat.com/))
-* optional: add your PagerDuty API token in `~/.config/pagerduty-cli/config.json`
+* add your PagerDuty API token in `$HOME/.config/pagerduty-cli/config.json`
 * optional: configure alias in `~/.bashrc`
   * alias ocm-container-stg="OCM_URL=stg ocm-container"
   * alias ocm-container-local='OCM_CONTAINER_LAUNCH_OPTS="-v $(pwd):/root/local" ocm-container'

--- a/README.md
+++ b/README.md
@@ -35,15 +35,14 @@ OCM Container also includes multiple scripts for your ease of use. For a quick o
 ## Installation:
 
 * clone this repo
-* `./init.sh`
+* `./init.sh` (repeat until all required fields are set)
 * `./build.sh` (while this is building you can run the rest in another tab until the final command)
-* edit the file `$HOME/.config/ocm-container/env.source`
-  * set your requested OCM_USER (for `ocm -u OCM_USER`)
-  * set your OFFLINE_ACCESS_TOKEN (from [cloud.redhat.com](https://cloud.redhat.com/))
-* optional:add your PagerDuty API token in `$HOME/.config/pagerduty-cli/config.json`
-* optional: configure alias in `~/.bashrc`
-  * alias ocm-container-stg="OCM_URL=stg ocm-container"
-  * alias ocm-container-local='OCM_CONTAINER_LAUNCH_OPTS="-v $(pwd):/root/local" ocm-container'
+* optional: have local aws keys (put on ${HOME}/.aws)
+* optional: have local gcp keys (put on ${HOME}/.config/gcloud)
+* optional: add alias in `~/.bashrc`
+  * `alias ocm-container-stg="OCM_URL=stg ocm-container"`
+  * `alias ocm-container-local='OCM_CONTAINER_LAUNCH_OPTS="-v ${PWD}:/root/local -w /root/local" ocm-container'`
+* optional: add your PagerDuty API token in `$HOME/.config/pagerduty-cli/config.json`
 * Connect to the VPN
 * `ocm-container {cluster-name}`
 
@@ -154,6 +153,7 @@ oc version >> report.txt
 ```
 
 We can run that on-container with the following script which runs on the host (~/myproject/on-host.sh):
+
 ```
 cat ~/myproject/on-host.sh
 #!/bin/bash
@@ -172,11 +172,14 @@ Would loop through all clusters listed in `clusters.txt` and then run `oc versio
 
 ### SSH Config
 If you're on a mac and you get an error similar to:
-```Cluster is internal. Initializing Tunnel... /root/.ssh/config: line 34: Bad configuration option: usekeychain```
+
+```
+Cluster is internal. Initializing Tunnel... /root/.ssh/config: line 34: Bad configuration option: usekeychain
+```
 you might need to add something similar to the following to your ssh config:
 
 ```
-> cat ~/.ssh/config | head
+$ cat ~/.ssh/config | head
 IgnoreUnknown   UseKeychain,AddKeysToAgent
 Host *
   <snip>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ OCM Container also includes multiple scripts for your ease of use. For a quick o
 * edit the file `$HOME/.config/ocm-container/env.source`
   * set your requested OCM_USER (for `ocm -u OCM_USER`)
   * set your OFFLINE_ACCESS_TOKEN (from [cloud.redhat.com](https://cloud.redhat.com/))
-* add your PagerDuty API token in `$HOME/.config/pagerduty-cli/config.json`
+* optional:add your PagerDuty API token in `$HOME/.config/pagerduty-cli/config.json`
 * optional: configure alias in `~/.bashrc`
   * alias ocm-container-stg="OCM_URL=stg ocm-container"
   * alias ocm-container-local='OCM_CONTAINER_LAUNCH_OPTS="-v $(pwd):/root/local" ocm-container'

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   cat <<EOF

--- a/env.source.sample
+++ b/env.source.sample
@@ -5,11 +5,12 @@
 ### How its used:
 ###     build.sh: time ${CONTAINER_SUBSYS}  build
 ###     ocm-container.sh: ${CONTAINER_SUBSYS} run -it --rm
+# REQUIRED: change this env to containerization tool
 export CONTAINER_SUBSYS="sudo docker"
 
 ### Select cli, options include:
 ### - "ocm"
-### - "moactl"
+### - "rosa"
 ### defaults to "ocm"
 export CLI=${CLI:-}
 
@@ -20,6 +21,7 @@ export CLI=${CLI:-}
 export OCM_URL=${OCM_URL:-}
 
 ### Your user for ocm, passed to ocm
+# REQUIRED: change this env to your local user
 export OCM_USER=${OCM_USER:-your_user}
 
 ### Default namespace for velero
@@ -28,9 +30,14 @@ export OCM_USER=${OCM_USER:-your_user}
 
 ### Your ocm Offline Access Token from
 ###     https://cloud.redhat.com/openshift/token
+# REQUIRED: change this env to offline token
 export OFFLINE_ACCESS_TOKEN="\
 your \
 token \
 here \
 "
 
+### Configure the PATH variable inside the container
+### the ${HOME}/.config/ocm-contianer is mounted to the container at /root/.config/ocm-container
+### this can be used to add additional tooling to the container without modifying the dockerfile
+# export PATH=${PATH}:/root/.config/ocm-container/bin

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   cat <<EOF

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -77,6 +77,14 @@ then
   SSH_AGENT_MOUNT="--mount type=bind,src=/run/host-services/ssh-auth.sock,target=/tmp/ssh.sock,readonly"
 fi
 
+### AWS token pull
+if [[ -d "${HOME}/.aws" ]]; then
+  AWSFILEMOUNT="
+-v ${HOME}/.aws/credentials:/root/.aws/credentials:ro 
+-v ${HOME}/.aws/config:/root/.aws/config:ro 
+"
+fi
+
 ### PagerDuty Token Mounting
 PAGERDUTY_TOKEN_FILE=".config/pagerduty-cli/config.json"
 if [ -f ${HOME}/${PAGERDUTY_TOKEN_FILE} ]
@@ -105,12 +113,11 @@ ${CONTAINER_SUBSYS} run $TTY --rm --privileged \
 ${INITIAL_CLUSTER_LOGIN} \
 -v ${CONFIG_DIR}:/root/.config/ocm-container:ro \
 -v ${HOME}/.ssh:/root/.ssh:ro \
--v ${HOME}/.aws/credentials:/root/.aws/credentials:ro \
--v ${HOME}/.aws/config:/root/.aws/config:ro \
 -v ${HOME}/.config/gcloud/active_config:/root/.config/gcloud/active_config:ro \
 -v ${HOME}/.config/gcloud/configurations/config_default:/root/.config/gcloud/configurations/config_default:ro \
 -v ${HOME}/.config/gcloud/credentials.db:/root/.config/gcloud/credentials_readonly.db:ro \
 ${PAGERDUTYFILEMOUNT} \
+${AWSFILEMOUNT} \
 ${SSH_AGENT_MOUNT} \
 ${OCM_CONTAINER_LAUNCH_OPTS} \
 ocm-container:${BUILD_TAG} ${EXEC_SCRIPT}

--- a/utils/bin/chgm
+++ b/utils/bin/chgm
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# OCM_CONTAINER_DOC: Run through the 'Cluster Has Gone Missing' process
 
 # Checks AWS cloudtrail logs for node shutdown events associated with a specific cluster_has_gone_missing (CHGM) alert,
 # and prompts to post a CHGM message to service log and silence the PD alert.

--- a/utils/bin/elevate.sh
+++ b/utils/bin/elevate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # OCM_CONTAINER_DOC: Adds the current user to the osd-sre-cluster-admins group
 
 ### This script is a temporary change until the group is changed

--- a/utils/bin/login.sh
+++ b/utils/bin/login.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # OCM_CONTAINER_DOC: Wrapper for `ocm-login` script
 
 echo "login.sh is being deprecated in favor of the command 'ocm-login'"

--- a/utils/bin/ocm-login
+++ b/utils/bin/ocm-login
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # OCM_CONTAINER_DOC: Logs into OCM and optionally directly into a cluster
 
 CLUSTERID=$1


### PR DESCRIPTION
refactor: make onboarding easier

    - add tool list to README.md
    - change all scripts to have the `env bash` instead of direct `bash`
    - add "required env changes" to the `./init.sh` (which can now run
      multiple times
    - won't print in `init.sh` if not required
    - add doc to `chgm` script