### PR TITLE
Bumps version for multiple utilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,19 +48,19 @@ ARG OC_VERSION="stable"
 ENV OC_URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC_VERSION}"
 
 # Replace version with a version number to pin a specific version (eg: "4.7.8")
-ARG ROSA_VERSION="tags/v1.1.0"
+ARG ROSA_VERSION="tags/v1.1.6"
 ENV ROSA_URL="https://api.github.com/repos/openshift/rosa/releases/${ROSA_VERSION}"
 
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
-ARG OSDCTL_VERSION="tags/v0.4.5"
+ARG OSDCTL_VERSION="tags/v0.7.0"
 ENV OSDCTL_URL="https://api.github.com/repos/openshift/osdctl/releases/${OSDCTL_VERSION}"
 
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
-ARG OCM_VERSION="tags/v0.1.55"
+ARG OCM_VERSION="tags/v0.1.60"
 ENV OCM_URL="https://api.github.com/repos/openshift-online/ocm-cli/releases/${OCM_VERSION}"
 
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
-ARG VELERO_VERSION="tags/v1.6.2"
+ARG VELERO_VERSION="tags/v1.7.1"
 ENV VELERO_URL="https://api.github.com/repos/vmware-tanzu/velero/releases/${VELERO_VERSION}"
 
 # Replace AWS client zipfile with specific file to pin to a specific version


### PR DESCRIPTION
This bumps the version for several utilities within ocm-container,
including the ROSA and OCM cli.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
