### PR TITLE
fix(chgm): make serviclog send

### DIFF
--- a/utils/bin/chgm
+++ b/utils/bin/chgm
@@ -116,7 +116,7 @@ then
 fi
 
 pd incident:ack -i ${PD_ALERT}
-osdctl servicelog post ${CLUSTER_UUID} -t ${SL_URL}
+osdctl servicelog post ${CLUSTER_UUID} -y -t ${SL_URL}
 pd incident:notes -i ${PD_ALERT} -n "$PD_CHGM_NOTE"
 pd incident:assign -i ${PD_ALERT} -u $PD_SILENT_TEST_USER
 pd incident:merge -i ${PD_ALERT} -I ${CHGM_PARENT_INCIDENT}

--- a/utils/bin/chgm
+++ b/utils/bin/chgm
@@ -106,7 +106,7 @@ then
   # If FORCE is not TRUE, then prompt for confirmation
   if [[ ${FORCE} != 'TRUE' ]]
   then
-    read -p 'Post a CHGM Servicelog and silence the alert? (Y/n)' -n 1 -r
+    read -p 'Post a CHGM Servicelog and silence the alert? (Y/n) ' -n 1 -r
     echo ''
     if [[ ! $REPLY =~ ^[Yy]$ ]]
     then
@@ -116,7 +116,7 @@ then
 fi
 
 pd incident:ack -i ${PD_ALERT}
-osdctl servicelog post -t ${SL_URL} -p CLUSTER_UUID=${CLUSTER_UUID}
+osdctl servicelog post ${CLUSTER_UUID} -t ${SL_URL}
 pd incident:notes -i ${PD_ALERT} -n "$PD_CHGM_NOTE"
 pd incident:assign -i ${PD_ALERT} -u $PD_SILENT_TEST_USER
 pd incident:merge -i ${PD_ALERT} -I ${CHGM_PARENT_INCIDENT}


### PR DESCRIPTION
the format of sending servicelogs has changed in 0.9.0, change the script accordingly
