### PR TITLE
fix(fzf): requires tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN microdnf --assumeyes install \
     python39 \ 
     python39-pip \
     rsync \
+    tar \
     vim-enhanced \
     wget \
     && microdnf clean all;


### PR DESCRIPTION
make the `fzf` installation pass accordingly
without it the `install` command fails on `tar not found`