### PR TITLE
Adds sudo command to work with some v4/utils scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN microdnf --assumeyes install \
     python39 \ 
     python39-pip \
     rsync \
+    sudo \# Redundant as root, but needed for some v4/utils scripts
     vim-enhanced \
     wget \
     && microdnf clean all;


### PR DESCRIPTION
Some of the shared v4/utils scripts have the sudo command built in.  This allows them to be used in ocm-container, if somewhat redundantly.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
