### PR TITLE
Adds env vars on container startup if id passed in

### DIFF
--- a/utils/bashrc.d/06-sre-utils.bashrc
+++ b/utils/bashrc.d/06-sre-utils.bashrc
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 
+function cluster_info_env_export(){
+  SEARCH_STRING="id like '$INITIAL_CLUSTER_LOGIN' or external_id like '$INITIAL_CLUSTER_LOGIN' or display_name like '$INITIAL_CLUSTER_LOGIN'"
+  cluster_details=$(ocm list clusters --parameter=search="(($SEARCH_STRING))" --columns "id, external_id, name" --no-headers)
+  CLUSTER_ID=$(awk '{print $1}' <<< $cluster_details)
+  CLUSTER_UUID=$(awk '{print $2}' <<< $cluster_details)
+  CLUSTER_NAME=$(awk '{print $3}' <<< $cluster_details)
+  export CLUSTER_ID CLUSTER_UUID CLUSTER_NAME
+}
+
 if [ -n "$INITIAL_CLUSTER_LOGIN" ]
 then
   sre-login $INITIAL_CLUSTER_LOGIN
+  cluster_info_env_export
 fi
 
 function cluster_function() {


### PR DESCRIPTION
This PR adds some helper env vars when you pass a cluster ID as startup.  Otherwise this is not run but available.
