### PR TITLE
Adds the `lnav` tool into the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN curl -sSlo epel-gpg https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
     && microdnf --assumeyes \
         install \
          sshuttle \
+         lnav \
     && microdnf clean all
 
 RUN git clone --depth 1 https://github.com/junegunn/fzf.git /root/.fzf \


### PR DESCRIPTION
LNAV is a useful tool for quickly digesting logs, including log streams. This PR adds the lnav tool to the build chain in order for this to be available while in the container.
