### PR TITLE
Adds auto-mapping for cluster console port and a wrapper for use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM ${BASE_IMAGE} as dnf-install
 # Replace version with a version number to pin a specific version (eg: "-123.0.0")
 ARG GCLOUD_VERSION=
 
+# OCM backplane console port to map
+ENV OCM_BACKPLANE_CONSOLE_PORT 9999
+
 # install gcloud-cli
 RUN mkdir -p /gcloud/bin
 ENV CLOUDSDK_PYTHON=/usr/bin/python3.6
@@ -283,6 +286,9 @@ RUN printf 'if [ -d ${HOME}/.bashrc.d ] ; then\n  for file in ~/.bashrc.d/*.bash
 # Cleanup Home Dir
 RUN rm -rf /root/anaconda* /root/original-ks.cfg /root/buildinfo
 
+# Set an exposable port for the cluster console proxy
+# Can be used with `-o "-P"` to map 9999 inside the container to a random port at runtime
+EXPOSE $OCM_BACKPLANE_CONSOLE_PORT 
 
 WORKDIR /root
 ENTRYPOINT ["/bin/bash"]

--- a/utils/bashrc.d/09-ocm.bashrc
+++ b/utils/bashrc.d/09-ocm.bashrc
@@ -18,3 +18,15 @@ elif [[ "${CLI}" == "moactl" ]]; then
 fi
 
 "${CLI}" login --token=$OFFLINE_ACCESS_TOKEN ${LOGIN_ENV}=$OCM_URL
+
+# Wrap the ocm backplane console command to handle automation for
+# port mapping inside the container
+ocm() {
+  if [[ "$@" =~ "backplane console" ]]; then
+    shift 2
+    echo "/root/.local/bin/cluster-console $@"
+    command /root/.local/bin/cluster-console
+  else
+    command ocm "$@"
+  fi
+}

--- a/utils/bin/cluster-console
+++ b/utils/bin/cluster-console
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [ "${CONTAINER_SUBSYS}" != "podman" ]
+then
+  echo "Cluster console inside OCM Container is currently only supported with Podman"
+  exit 1
+fi
+
+# if the file doesn't exist, or is empty, exit
+if [ ! -f /tmp/portmap ] || [ ! -s /tmp/portmap ]
+then
+  echo "External port not mapped for cluster console, exiting..."
+  exit 1
+fi
+
+exec ocm backplane console --port $OCM_BACKPLANE_CONSOLE_PORT  --image=quay.io/openshift/origin-console \
+  | sed "s/${OCM_BACKPLANE_CONSOLE_PORT}/$(cat /tmp/portmap)/"


### PR DESCRIPTION
This PR adds auto-mapping of a random port to the `ocm backplane console` port used inside the container, allowing `ocm backplane console` to behave the same way inside ocm-container as outside.  

Launching ocm-contianer with no other options is required, and running `ocm backplane console` inside the container will detect and use the random port and print the link to copy/paste or click to open outside the container:

```shell
$ ocm-container <CLUSTERNAME>
Logging into OCM
Logging into cluster REDACTED
starting sshuttle for REDACTED
REDACTED password: 
[~ {production} (REDACTED:default)]$ ocm backplane console
/root/.local/bin/cluster-console 
Starting console for cluster REDACTED
== Console is available at http://127.0.0.1:36497 ==
```

This also includes a way to disable the automatic port mapping if desired, by passing the `-dp` or `--disable-console-port` option to ocm-container at runtime.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
