### PR TITLE
Add config to mount a scratch directory

### DIFF
--- a/env.source.sample
+++ b/env.source.sample
@@ -45,9 +45,14 @@ here \
 # export OPS_UTILS_DIR=/Users/myuser/path/to/ops-sop/v4/utils
 
 ### OPS_UTILS_DIR_RW is a boolean flag to allow mounting the ops-sop directory as
-### read/write instead of the default readonly. This is useful when debugging or 
+### read/write instead of the default readonly. This is useful when debugging or
 ### writing a script.
 # export OPS_UTILS_DIR_RW=true
+
+### SCRATCH_DIR
+### the SCRATCH_DIR setting is used to mount an optional scratch directory into your container.
+### This will be mounted under /home/scratch
+# export SCRATCH_DIR='/home/myuser/ocm-scratch-dir/'
 
 ### Configure the PATH variable inside the container
 ### the ${HOME}/.config/ocm-contianer is mounted to the container at /root/.config/ocm-container

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -87,8 +87,8 @@ fi
 ### AWS token pull
 if [[ -d "${HOME}/.aws" ]]; then
   AWSFILEMOUNT="
--v ${HOME}/.aws/credentials:/root/.aws/credentials:ro 
--v ${HOME}/.aws/config:/root/.aws/config:ro 
+-v ${HOME}/.aws/credentials:/root/.aws/credentials:ro
+-v ${HOME}/.aws/config:/root/.aws/config:ro
 "
 fi
 
@@ -102,10 +102,10 @@ fi
 ### Google Cloud CLI config mounting
 if [ -d ${HOME}/.config/gcloud ]; then
   GOOGLECLOUDFILEMOUNT="
--v ${HOME}/.config/gcloud/active_config:/root/.config/gcloud/active_config_readonly:ro 
--v ${HOME}/.config/gcloud/configurations/config_default:/root/.config/gcloud/configurations/config_default_readonly:ro 
--v ${HOME}/.config/gcloud/credentials.db:/root/.config/gcloud/credentials_readonly.db:ro 
--v ${HOME}/.config/gcloud/access_tokens.db:/root/.config/gcloud/access_tokens_readonly.db:ro 
+-v ${HOME}/.config/gcloud/active_config:/root/.config/gcloud/active_config_readonly:ro
+-v ${HOME}/.config/gcloud/configurations/config_default:/root/.config/gcloud/configurations/config_default_readonly:ro
+-v ${HOME}/.config/gcloud/credentials.db:/root/.config/gcloud/credentials_readonly.db:ro
+-v ${HOME}/.config/gcloud/access_tokens.db:/root/.config/gcloud/access_tokens_readonly.db:ro
 "
 fi
 
@@ -118,6 +118,12 @@ if [ -d "${OPS_UTILS_DIR}" ]; then
   OPS_UTILS_DIR_MOUNT="
 -v ${OPS_UTILS_DIR}:/root/sop-utils:${OPS_UTILS_DIR_RW_FLAG}
 "
+fi
+
+### mount a scratch dir
+if [ -n "$SCRATCH_DIR" ]
+then
+  SCRATCH_DIR_MOUNT="-v ${SCRATCH_DIR}:/home/scratch/"
 fi
 
 ### Automatic Login Detection
@@ -150,6 +156,7 @@ ${PAGERDUTYFILEMOUNT} \
 ${AWSFILEMOUNT} \
 ${SSH_AGENT_MOUNT} \
 ${OPS_UTILS_DIR_MOUNT} \
+${SCRATCH_DIR_MOUNT} \
 -v ${HOME}/.ssh/sockets:/root/.ssh/sockets \
 ${PORT_MAP_OPTS} \
 ${OCM_CONTAINER_LAUNCH_OPTS} \
@@ -166,4 +173,3 @@ then
 fi
 
 $CONTAINER_SUBSYS attach $CONTAINER
-

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -123,7 +123,7 @@ fi
 ### mount a scratch dir
 if [ -n "$SCRATCH_DIR" ]
 then
-  SCRATCH_DIR_MOUNT="-v ${SCRATCH_DIR}:/home/scratch/"
+  SCRATCH_DIR_MOUNT="-v ${SCRATCH_DIR}:/root/scratch/"
 fi
 
 ### Automatic Login Detection


### PR DESCRIPTION
This adds an optional config to mount a scratch directory into your ocm container.
