### PR TITLE
Prevents terminal multiplexer from re-logging in when new pane is created

### DIFF
--- a/utils/bashrc.d/06-sre-utils.bashrc
+++ b/utils/bashrc.d/06-sre-utils.bashrc
@@ -9,7 +9,9 @@ function cluster_info_env_export(){
   export CLUSTER_ID CLUSTER_UUID CLUSTER_NAME
 }
 
-if [ -n "$INITIAL_CLUSTER_LOGIN" ]
+# oc config current-context will return a 1 for newly-opened ocm-container
+# This prevents another attempt at login if using a terminal multiplexer
+if ! oc config current-context &>/dev/null && [ -n "$INITIAL_CLUSTER_LOGIN" ]
 then
   sre-login $INITIAL_CLUSTER_LOGIN
   cluster_info_env_export


### PR DESCRIPTION
Adds a check for existing cluster context to the INITIAL_CLUSTER_LOGIN flow, so using a terminal multiplexer won't attempt to re-login each time a new pane is opened.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
