### PR TITLE
Checks to make sure backplane is installed for sre-login script

### DIFF
--- a/utils/bin/sre-login
+++ b/utils/bin/sre-login
@@ -1,6 +1,13 @@
 #!/bin/bash -e
 # OCM_CONTAINER_DOC: Logs into a cluster via the command line
 
+# Check that backplane is installed
+if ! ocm backplane version > /dev/null
+then
+  echo "The OCM backplane plugin must be installed for automatic cluster login."
+  exit 1
+fi
+
 if [ -z $1 ]
 then
   echo "First parameter must be a cluster"
@@ -55,6 +62,7 @@ cluster_id=$(jq -r '.id' <<< "$clusterjson")
 cluster_listening=$(jq -r '.api.listening' <<< "$clusterjson")
 
 # Login to the Cluster
+
 echo "Cluster ID: $cluster_id"
 ocm backplane tunnel -D > tunnel.log
 exec ocm backplane login ${cluster_id}


### PR DESCRIPTION
Backplane must be installed for sre-login to work, and there have been a number of questions in the last two or three weeks about this.  This PR adds a check for backplane and bombs out with a specific error message if backplane is not installed.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
