### PR TITLE
ssh sockets fixes

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -142,11 +142,11 @@ then
   PORT_MAP_OPTS="--publish-all"
 fi
 
-if [ "${DISABLE_SOCKET_MOUNT}" == "true" ]
+### Mount ssh sockets dir used for ssh connection multiplexing
+SSH_SOCKETS_DIR=${HOME}/.ssh/sockets
+if [ -d "${SSH_SOCKETS_DIR}" ] && [ "${DISABLE_SSH_MULTIPLEXING}" != "true" ] 
 then
-  SOCKET_MOUNT="-v /root/.ssh/sockets"
-else
-  SOCKET_MOUNT="-v ${HOME}/.ssh/sockets:/root/.ssh/sockets"
+ SSH_SOCKETS_MOUNT="-v ${SSH_SOCKETS_DIR}:/root/.ssh/sockets"
 fi
 
 ### start container
@@ -162,9 +162,9 @@ ${GOOGLECLOUDFILEMOUNT} \
 ${PAGERDUTYFILEMOUNT} \
 ${AWSFILEMOUNT} \
 ${SSH_AGENT_MOUNT} \
+${SSH_SOCKETS_MOUNT} \
 ${OPS_UTILS_DIR_MOUNT} \
 ${SCRATCH_DIR_MOUNT} \
-${SOCKET_MOUNT} \
 ${PORT_MAP_OPTS} \
 ${OCM_CONTAINER_LAUNCH_OPTS} \
 ocm-container:${BUILD_TAG} ${EXEC_SCRIPT})


### PR DESCRIPTION
I've just built a fresh ocm container and noticed unexpected behavior. If my ~/.ssh/sockets is missing, I'm getting an error:
```
$ ocm-container mytestcluster
Error: statfs /home/ansible/.ssh/sockets: no such file or directory
Error: start requires at least one argument
Error: no names or ids specified
Error: name or ID cannot be empty
Error: "podman attach" requires a name, id, or the "--latest" flag
``` 
if I use `DISABLE_SOCKET_MOUNT` empty mount is added causing an error:
```
$ DISABLE_SOCKET_MOUNT=true ocm-container bla
Error: OCI runtime error: unable to start container "d36ffd6d0f4ddaf25739258507baca69d13067d8484a45c4fa5d5118e4955121": runc: runc create failed: unable to start container process: error during container init: error mounting "/home/ansible/.local/share/containers/storage/volumes/c8b16f1f2c270363ab7f2f010be05f1fd688a94ef0f1663964b1462e733d5626/_data" to rootfs at "/root/.ssh/sockets": mkdir /home/ansible/.local/share/containers/storage/overlay/4a4eecfb21a5d84fb6214199bdaa5b8c7bd8e53ec54bbe38160ab50de814ac64/merged/root/.ssh/sockets: read-only file system
Error: inspecting object: no such object: "d36ffd6d0f4ddaf25739258507baca69d13067d8484a45c4fa5d5118e4955121"
Error: container "d36ffd6d0f4ddaf25739258507baca69d13067d8484a45c4fa5d5118e4955121" does not exist
Error: no container with name or ID "d36ffd6d0f4ddaf25739258507baca69d13067d8484a45c4fa5d5118e4955121" found: no such container
```

Fixes in this PR
    - mount ssh sockets based on the presence of ssh sockets dir and if DISABLE_SOCKET_MOUNT var is not set to 'true'
    - don't attempt to mount empty dir when sockets dir not found
    - move ssh sockets mount param closer to ssh agent param since both args mount ssh sockets, will make it easier for debugging ssh socket issues

