### PR TITLE
update yq to v4.28.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ ENV VELERO_URL="https://api.github.com/repos/${VELERO_URL_SLUG}/releases/${VELER
 
 # Add `yq` utility for programatic yaml parsing
 # the URL_SLUG is for checking the releasenotes when a version updates
-ARG YQ_VERSION="tags/v4.25.3"
+ARG YQ_VERSION="tags/v4.28.1"
 ENV YQ_URL_SLUG="mikefarah/yq"
 ENV YQ_URL="https://api.github.com/repos/${YQ_URL_SLUG}/releases/${YQ_VERSION}"
 


### PR DESCRIPTION
update yq to v4.28.1 - 
- image builds https://quay.io/repository/todabasi_openshift/ocm-container/build/bd38cd33-7fa9-420e-9e68-6b8a6d6d1318
- yq version confirmed on the container
```
$ yq --version
yq (https://github.com/mikefarah/yq/) version 4.28.1
```

to test 
```
podman pull quay.io/todabasi_openshift/ocm-container
```