### PR TITLE
Prevents unnecessary parent shell exit on failure; formatting fixes

### DIFF
--- a/utils/bashrc.d/09-ocm.bashrc
+++ b/utils/bashrc.d/09-ocm.bashrc
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 
-if [ "x${OFFLINE_ACCESS_TOKEN}" == "x" ]; then
-  echo "FAILURE: must set env variable OFFLINE_ACCESS_TOKEN";
-  exit 1;
+if [ "x${OFFLINE_ACCESS_TOKEN}" == "x" ]
+then
+  echo "WARNING: must set env variable OFFLINE_ACCESS_TOKEN for automatic OCM login"
+  return
 fi
 
-if [ "$OCM_URL" == "" ];
+if [ "$OCM_URL" == "" ]
 then
   OCM_URL="https://api.openshift.com"
 fi
 
 CLI="${CLI:-ocm}"
-if [[ "${CLI}" == "ocm" ]]; then
-  LOGIN_ENV='--url';
-elif [[ "${CLI}" == "moactl" ]]; then
-  LOGIN_ENV='--env';
+if [[ "${CLI}" == "ocm" ]]
+then
+  LOGIN_ENV='--url'
+elif [[ "${CLI}" == "moactl" ]]
+then
+  LOGIN_ENV='--env'
 fi
 
 "${CLI}" login --token=$OFFLINE_ACCESS_TOKEN ${LOGIN_ENV}=$OCM_URL
@@ -22,7 +25,8 @@ fi
 # Wrap the ocm backplane console command to handle automation for
 # port mapping inside the container
 ocm() {
-  if [[ "$@" =~ "backplane console" ]]; then
+  if [[ "$@" =~ "backplane console" ]]
+  then
     shift 2
     echo "/root/.local/bin/cluster-console $@"
     command /root/.local/bin/cluster-console


### PR DESCRIPTION
Replacing the `exit 1` with `return` should prevent unnecessarily
closing the parent shell when skipping the rest of the sourcing due to
the missing `OFFLINE_ACCESS_TOKEN` variable.

The `exit 1` prevents the use of bash to troubleshoot issues in
partly-build ocm-contianer images or running the container image without
the bootstrapping built in for OCM.

Also, removes unnecessary `;` linebreak characters, and standardizes
if/elif/fi formatting.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
