### PR TITLE
jira cli config

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -92,6 +92,18 @@ if [[ -d "${HOME}/.aws" ]]; then
 "
 fi
 
+### JIRA Token Mounting
+JIRA_CONFIG_DIR=".config/.jira/"
+if [ -d ${HOME}/${JIRA_CONFIG_DIR} ]
+then
+  JIRAFILEMOUNT="-v ${HOME}/${JIRA_CONFIG_DIR}:/root/${JIRA_CONFIG_DIR}:ro"
+fi
+
+if [ -f ${HOME}/${JIRA_CONFIG_DIR}/token.json ]
+then
+  JIRATOKENCONFIG="-e JIRA_API_TOKEN=$(jq -r .token ${HOME}/${JIRA_CONFIG_DIR}/token.json) -e JIRA_AUTH_TYPE=bearer"
+fi
+
 ### PagerDuty Token Mounting
 PAGERDUTY_TOKEN_FILE=".config/pagerduty-cli/config.json"
 if [ -f ${HOME}/${PAGERDUTY_TOKEN_FILE} ]
@@ -155,10 +167,12 @@ CONTAINER=$(${CONTAINER_SUBSYS} create $TTY --rm --privileged \
 -e "USER" \
 -e "SSH_AUTH_SOCK=/tmp/ssh.sock" \
 -e "OFFLINE_ACCESS_TOKEN" \
+${JIRATOKENCONFIG} \
 ${INITIAL_CLUSTER_LOGIN} \
 -v ${CONFIG_DIR}:/root/.config/ocm-container:ro \
 -v ${HOME}/.ssh:/root/.ssh:ro \
 ${GOOGLECLOUDFILEMOUNT} \
+${JIRAFILEMOUNT} \
 ${PAGERDUTYFILEMOUNT} \
 ${AWSFILEMOUNT} \
 ${SSH_AGENT_MOUNT} \


### PR DESCRIPTION
Adds support for the [Jira CLI
tool](https://github.com/ankitpokhrel/jira-cli).

Access token must be stored in json format `{"token": "<TOKEN>"}` in
`~/.config/.jira/token.json` for automatic token authentication setup.

The first time it is just, you must run `jira init`, and copy the
resulting `.config.yaml` file from the container to
`~/.config/.jira/.config.yaml` on the host to make the setup persistent.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>