### PR TITLE
Fix `command not found` error during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,9 +105,9 @@ WORKDIR /oc
 # Download the checksum
 RUN curl -sSLf ${OC_URL}/sha256sum.txt -o sha256sum.txt
 # Download the binary tarball
-RUN /bin/bash -c "curl -sSLf -O ${OC_URL}/$(awk -v asset="openshift-client-linux" '$0~asset {print $2}' sha256sum.txt)"
+RUN /bin/bash -c "curl -sSLf -O ${OC_URL}/$(awk -v asset="openshift-client-linux-4" '$0~asset {print $2}' sha256sum.txt)"
 # Check the tarball and checksum match
-RUN bash -c 'sha256sum --check <( grep openshift-client-linux sha256sum.txt )'
+RUN bash -c 'sha256sum --check <( grep openshift-client-linux-4 sha256sum.txt )'
 RUN tar --extract --gunzip --no-same-owner --directory /out oc --file *.tar.gz
 RUN chmod -R +x /out
 


### PR DESCRIPTION
Currently building ocm-container fails with the following error message:
```
[3/11] STEP 7/10: RUN /bin/bash -c "curl -sSLf -O ${OC_URL}/$(awk -v asset="openshift-client-linux" '$0~asset {print $2}' sha256sum.txt)"
/bin/bash: line 1: openshift-client-linux-arm64-4.11.16.tar.gz: command not found
Error: building at STEP "RUN /bin/bash -c "curl -sSLf -O ${OC_URL}/$(awk -v asset="openshift-client-linux" '$0~asset {print $2}' sha256sum.txt)"": while running runtime: exit status 127
```

The issue seems to be that the downloaded sha56sum.txt file now contains a line reading `openshift-client-linux-arm64-4.11.16.tar.gz` which breaks the mechanism by which the file name to download is being determined. This PR 'fixes' that by maching for `openshift-client-linux-4`so that `openshift-client-linux-arm64` is being excluded.