### PR TITLE
Fixes oc binary selection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,9 +105,9 @@ WORKDIR /oc
 # Download the checksum
 RUN curl -sSLf ${OC_URL}/sha256sum.txt -o sha256sum.txt
 # Download the binary tarball
-RUN /bin/bash -c "curl -sSLf -O ${OC_URL}/$(awk -v asset="openshift-client-linux" '$0~asset {print $2}' sha256sum.txt)"
+RUN /bin/bash -c "curl -sSLf -O ${OC_URL}/$(awk '/openshift-client-linux-([[:digit:]]+.)([[:digit:]]+.)([[:digit:]]+.).tar.gz/{print $2}' sha256sum.txt)"
 # Check the tarball and checksum match
-RUN bash -c 'sha256sum --check <( grep openshift-client-linux sha256sum.txt )'
+RUN bash -c 'sha256sum --check <(awk "/openshift-client-linux-([[:digit:]]+.)([[:digit:]]+.)([[:digit:]]+.).tar.gz/{print}" sha256sum.txt)'
 RUN tar --extract --gunzip --no-same-owner --directory /out oc --file *.tar.gz
 RUN chmod -R +x /out
 


### PR DESCRIPTION
Linux arm64 binaries were recently added to the x86_64 client mirror
directory, breaking the selection of the proper binary for building
ocm-container.  This selects the binary properly with a more stringent
regex match.
