### PR TITLE
 Adds update to address CVEs and patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 env.source
+.github/*
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 ### Pre-install yum stuff
-ARG BASE_IMAGE=quay.io/app-sre/ubi8-ubi-minimal:8.6-854
-FROM ${BASE_IMAGE} as dnf-install
+ARG BASE_IMAGE=quay.io/app-sre/ubi8-ubi-minimal:8.7-923
+FROM ${BASE_IMAGE} as base-update
+
+RUN microdnf --assumeyes update \
+      && microdnf clean all \
+      && rm -rf /var/yum/cache
+
+FROM base-update as dnf-install
 
 # Replace version with a version number to pin a specific version (eg: "-123.0.0")
 ARG GCLOUD_VERSION=
@@ -35,6 +41,7 @@ RUN microdnf --assumeyes install \
     vim-enhanced \
     wget \
     && microdnf clean all \
+    && rm -rf /var/yum/cache
     && update-alternatives --set python3 /usr/bin/python3.9;
 
 RUN curl -sSlo epel-gpg https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8 \


### PR DESCRIPTION
A number of libraries (curl, gnupg, etc) have CVEs in the base image
that won't be patched until the next base image version is released, so
this adds an initial step to run a microdnf update as a first stage of
the build.

Also adds .github/* to .gitignore, to skip merging local github actions from personal branches.