### PR TITLE
[OSD-15271] skip osdctl version check when generating bash completion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -270,7 +270,7 @@ RUN aws_completer bash > /etc/bash_completion.d/aws-cli
 RUN jira completion bash > /etc/bash_completion.d/jira
 RUN oc completion bash > /etc/bash_completion.d/oc
 RUN ocm completion > /etc/bash_completion.d/ocm
-RUN osdctl completion bash > /etc/bash_completion.d/osdctl
+RUN osdctl completion bash --skip-version-check > /etc/bash_completion.d/osdctl
 RUN rosa completion bash > /etc/bash_completion.d/rosa
 RUN yq --version
 


### PR DESCRIPTION
Since osdctl started to check for version, ocm-container build can get stuck due to required user input for `osdctl completion` command as seen from:

```
$ ./osdctl completion bash
The current version () is different than the latest released version (v0.14.0).
It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.
Please confirm that you would like to continue with [y|n]
```