### PR TITLE
Enable bracketed paste for bash sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -297,7 +297,9 @@ RUN printf 'if [ -d ${HOME}/.bashrc.d ] ; then\n  for file in ~/.bashrc.d/*.bash
     && printf "[ -f ~/.fzf.bash ] && source ~/.fzf.bash" >> /root/.bashrc \
     # Setup pdcli autocomplete \
     &&  printf 'eval $(pd autocomplete:script bash)' >> /root/.bashrc.d/99-pdcli.bashrc \
-    && bash -c "SHELL=/bin/bash pd autocomplete --refresh-cache"
+    && bash -c "SHELL=/bin/bash pd autocomplete --refresh-cache" \
+    # don't run automatically run commands when pasting from clipboard with a newline
+    && printf "set enable-bracketed-paste on\n" >> /root/.inputrc
 
 # Cleanup Home Dir
 RUN rm -rf /root/anaconda* /root/original-ks.cfg /root/buildinfo


### PR DESCRIPTION
This PR makes sure, that [bracketed paste](https://cirw.in/blog/bracketed-paste) is enabled by default for the bash session inside the container.

The implication is, that commands that get pasted into the ocm-container shell session don't get executed immediately. Instead, they will be run only after the user actually presses the enter key.