### PR TITLE
use full file suffix for omc binary download to fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,9 +128,9 @@ WORKDIR /omc
 # Download the checksum
 RUN /bin/bash -c "curl -sSLf $(curl -sSLf ${OMC_URL} -o - | jq -r '.assets[] | select(.name|test("checksums.txt")) | .browser_download_url') -o md5sum.txt"
 # Download the binary
-RUN /bin/bash -c "curl -sSLf -O $(curl -sSLf ${OMC_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_x86_64")) | .browser_download_url')"
+RUN /bin/bash -c "curl -sSLf -O $(curl -sSLf ${OMC_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_x86_64.tar.gz")) | .browser_download_url')"
 # Check the binary and checksum match
-RUN bash -c 'md5sum --check <( grep Linux_x86_64  md5sum.txt )'
+RUN bash -c 'md5sum --check <( grep Linux_x86_64.tar.gz  md5sum.txt )'
 RUN tar --extract --gunzip --no-same-owner --directory /out omc --file *.tar.gz
 RUN chmod -R +x /out
 


### PR DESCRIPTION
use full file suffix for omc binary download, fixes build error:
```
[6/12] STEP 8/11: RUN /bin/bash -c "curl -sSLf -O $(curl -sSLf ${OMC_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_x86_64")) | .browser_download_url')"
/bin/bash: line 2: https://github.com/gmeghnag/omc/releases/download/v2.5.0/omc_Linux_x86_64.tar.gz: No such file or directory
Error: building at STEP "RUN /bin/bash -c "curl -sSLf -O $(curl -sSLf ${OMC_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_x86_64")) | .browser_download_url')"": while running runtime: exit status 127
```
this is because 
```
OMC_URL=https://api.github.com/repos/gmeghnag/omc/releases/tags/v2.5.0
curl -sSLf ${OMC_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_x86_64")) | .browser_download_url'
```
returns 2 results:
```
https://github.com/gmeghnag/omc/releases/download/v2.5.0/omc_Linux_x86_64
https://github.com/gmeghnag/omc/releases/download/v2.5.0/omc_Linux_x86_64.tar.gz
```
but curl expects 1 url, 
using omc_Linux_x86_64.tar.gz instead of omc_Linux_x86_64 because it's 3+ times smaller 