### PR TITLE
Update ocm cli to 0.1.66

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN chmod -R +x /out
 FROM builder as ocm-builder
 # Add `ocm` utility for interacting with the ocm-api
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
-ARG OCM_VERSION="tags/v0.1.65"
+ARG OCM_VERSION="tags/v0.1.66"
 ENV OCM_URL_SLUG="openshift-online/ocm-cli"
 ENV OCM_URL="https://api.github.com/repos/${OCM_URL_SLUG}/releases/${OCM_VERSION}"
 


### PR DESCRIPTION
Updates ocm-cli to the [0.1.66 release version](https://github.com/openshift-online/ocm-cli/releases/tag/v0.1.66)

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
