### PR TITLE
Adds optional PersonalizationFile config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Related tools added to image:
 * Credentials are destroyed on container exit (container has `--rm` flag set)
 * Displays current cluster-name, and OpenShift project (`oc project`) in bash PS1
 * Ability to login to private clusters without using a browser
+* Ability to personalize it - `$PERSONALIZATION_FILE` can be set in `env.source` which automatically sources the file (or `.sh` files within a directory if PERSONALIZATION_FILE points to a directory) allowing for personal customizations
+* Infinitely extendable:
+  * Create your own Containerfile and reference `FROM: ocm-container:latest` and add whatever binaries you want on top
+  * Mount as many other directories as you want with the `-o` flag (ex: want your vim config? `-o '-v /path/to/.vim:/root/.vim'`)
 
 OCM Container also includes multiple scripts for your ease of use. For a quick overview of what is available, run `list-utils`.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,30 @@ Launch options provide you a way to add other volumes, add environment variables
 
 _NOTE_: Using the flag for launch options will then NOT use the environment variable `OCM_CONTAINER_LAUNCH_OPTS`
 
+## Personalize it
+
+There are many options to personalize your ocm-container experience. For example, if you want to have your vim config passed in and available all the time, you could do something like this:
+
+``` sh
+alias occ=`ocm-container -o "-v /home/myuser/.vim:/root/.vim"`
+```
+
+Another common option is to have additional packages available that do not come in the standard build. You can create an additional Containerfile to run after you build the standard ocm-container build:
+
+``` dockerfile
+FROM ocm-container:latest
+
+RUN microdnf --assumeyes --nodocs update \
+    && microdnf --assumeyes --nodocs install \
+        lnav \
+    && microdnf clean all \
+    && rm -rf /var/cache/yum
+```
+
+```
+NOTE: When customizing ocm-container, use caution not to overwrite core tooling or default functionality in order to keep to the spirit of reproducable environments between SREs.  We offer the ability to customize your environment to provide the best experience, however the main goal of this tool is that all SREs have a consistent environment so that tooling "just works" between SREs.
+```
+
 ## Automatic Login to a cluster:
 
 ```

--- a/env.source.sample
+++ b/env.source.sample
@@ -58,3 +58,11 @@ here \
 ### the ${HOME}/.config/ocm-contianer is mounted to the container at /root/.config/ocm-container
 ### this can be used to add additional tooling to the container without modifying the dockerfile
 # export PATH=${PATH}:/root/.config/ocm-container/bin
+
+### ALIAS_FILE
+### The ALIAS_FILE setting is used to define an injectible set of aliases.
+### This can be either a single file or a directory of sh files.
+### In the case of a single file, it will be mounted at /root/.config/aliases.d/aliases.sh
+### In the case of a directory being defined, all *.sh files in that directory
+### will be `source`'d.
+#export ALIAS_FILE='/home/myuser/path/to/my/defined-aliases.sh

--- a/env.source.sample
+++ b/env.source.sample
@@ -59,10 +59,10 @@ here \
 ### this can be used to add additional tooling to the container without modifying the dockerfile
 # export PATH=${PATH}:/root/.config/ocm-container/bin
 
-### ALIAS_FILE
-### The ALIAS_FILE setting is used to define an injectible set of aliases.
+### PERSONALIZATION_FILE
+### The PERSONALIZATION_FILE setting is used to define an injectible set of aliases.
 ### This can be either a single file or a directory of sh files.
-### In the case of a single file, it will be mounted at /root/.config/aliases.d/aliases.sh
+### In the case of a single file, it will be mounted at /root/.config/personalization.d/personalization.sh
 ### In the case of a directory being defined, all *.sh files in that directory
 ### will be `source`'d.
-#export ALIAS_FILE='/home/myuser/path/to/my/defined-aliases.sh
+#export PERSONALIZATION_FILE=/home/myuser/path/to/my/defined-personalizations.sh

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -179,6 +179,20 @@ then
   PORT_MAP_OPTS="--publish-all"
 fi
 
+if [ -n "$ALIAS_FILE" ]
+then
+  if [ -f "$ALIAS_FILE" ]
+  then
+    ALIASMOUNT="-v ${ALIAS_FILE}:/root/.config/alias.d/alias.sh"
+  elif [ -d "$ALIASFILE" ]
+  then
+    ALIASMOUNT="-v ${ALIAS_FILE}:/root/.config/alias.d"
+  else
+    echo "Alias File is not a valid file or directory. Check your config."
+    exit 3
+  fi
+fi
+
 ### start container
 CONTAINER=$(${CONTAINER_SUBSYS} create $TTY --rm --privileged \
 -e "OCM_URL" \
@@ -200,6 +214,7 @@ ${OPS_UTILS_DIR_MOUNT} \
 ${SCRATCH_DIR_MOUNT} \
 ${PORT_MAP_OPTS} \
 ${OCM_CONTAINER_LAUNCH_OPTS} \
+${ALIASMOUNT} \
 ocm-container:${BUILD_TAG} ${EXEC_SCRIPT})
 
 $CONTAINER_SUBSYS start $CONTAINER > /dev/null

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -184,7 +184,7 @@ then
   if [ -f "$ALIAS_FILE" ]
   then
     ALIASMOUNT="-v ${ALIAS_FILE}:/root/.config/alias.d/alias.sh"
-  elif [ -d "$ALIASFILE" ]
+  elif [ -d "$ALIAS_FILE" ]
   then
     ALIASMOUNT="-v ${ALIAS_FILE}:/root/.config/alias.d"
   else

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -179,16 +179,16 @@ then
   PORT_MAP_OPTS="--publish-all"
 fi
 
-if [ -n "$ALIAS_FILE" ]
+if [ -n "$PERSONALIZATION_FILE" ]
 then
-  if [ -f "$ALIAS_FILE" ]
+  if [ -f "$PERSONALIZATION_FILE" ]
   then
-    ALIASMOUNT="-v ${ALIAS_FILE}:/root/.config/alias.d/alias.sh"
-  elif [ -d "$ALIAS_FILE" ]
+    PERSONALIZATION_MOUNT="-v ${PERSONALIZATION_FILE}:/root/.config/personalizations.d/personalizations.sh"
+  elif [ -d "$PERSONALIZATION_FILE" ]
   then
-    ALIASMOUNT="-v ${ALIAS_FILE}:/root/.config/alias.d"
+    PERSONALIZATION_MOUNT="-v ${PERSONALIZATION_FILE}:/root/.config/personalizations.d"
   else
-    echo "Alias File is not a valid file or directory. Check your config."
+    echo "Personalizations File is not a valid file or directory. Check your config."
     exit 3
   fi
 fi
@@ -214,7 +214,7 @@ ${OPS_UTILS_DIR_MOUNT} \
 ${SCRATCH_DIR_MOUNT} \
 ${PORT_MAP_OPTS} \
 ${OCM_CONTAINER_LAUNCH_OPTS} \
-${ALIASMOUNT} \
+${PERSONALIZATION_MOUNT} \
 ocm-container:${BUILD_TAG} ${EXEC_SCRIPT})
 
 $CONTAINER_SUBSYS start $CONTAINER > /dev/null

--- a/utils/bashrc.d/99-alias.bashrc
+++ b/utils/bashrc.d/99-alias.bashrc
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-if [ -d /root/.config/alias.d ]
-then
-    source /root/.config/alias.d/*.sh
-fi

--- a/utils/bashrc.d/99-alias.bashrc
+++ b/utils/bashrc.d/99-alias.bashrc
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -d /root/.config/alias.d ]
+then
+    source /root/.config/alias.d/*.sh
+fi

--- a/utils/bashrc.d/99-personalizations.bashrc
+++ b/utils/bashrc.d/99-personalizations.bashrc
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -d /root/.config/personalizations.d ]
+then
+    source /root/.config/personalizations.d/*.sh
+fi


### PR DESCRIPTION
Over my last shift during the multitude of investigations I found myself wishing I had somewhere that automatically sourced some convenient aliases into ocm-container.  This adds that configuration.

The idea here being that each individual SRE can define their own set of helpful aliases rather than being forced to use the same list of them.