### PR TITLE
Add oc alias fn to append compliance reason

### DIFF
--- a/utils/bashrc.d/06-sre-utils.bashrc
+++ b/utils/bashrc.d/06-sre-utils.bashrc
@@ -20,3 +20,33 @@ fi
 function cluster_function() {
   oc config view  --minify --output 'jsonpath={..server}' | cut -d. -f2-4
 }
+
+function oc() {
+    if [[ ! "$@" =~ "--reason" ]]
+    then
+        /usr/local/bin/oc $@
+        return $?
+    fi
+
+    let i=0
+    for arg in "$@"
+    do
+        if [[ $arg == "--reason" ]]
+        then
+            let reason_flag_pos=$i
+            let reason_text_pos=$i+1
+        fi
+
+        # get elevation text
+        if [[ $i == $reason_text_pos ]]
+        then
+            reason_text=$arg
+        fi
+
+        let i++
+    done
+
+    OC_POS_ARGS=( "${@:1:$reason_flag_pos}" )
+
+    ocm backplane elevate "$reason_text" -- ${OC_POS_ARGS[@]}
+}


### PR DESCRIPTION
Adds an ergonomic shell expansion that allows this: 
`oc get po -A --reason 'compliance'`

to be expanded to this:
`ocm backplane elevate 'compliance' -- get po -A

Video: 
[Screencast from 2023-04-21 17-43-20.webm](https://user-images.githubusercontent.com/28124379/233574963-b30a426c-b274-4597-b710-0508c04579e7.webm)
To test:
Run `make build-ocm-container` in https://github.com/openshift/backplane-cli to use the latest version. Make sure that `.config/backplane/config.json` is set correctly (reach out to the backplane team for how to do this). 

Run the above command. The `Impersonate-Extra-Reason` header should get added to your oc request. 

Current drawbacks: 
Only works if `--reason` is appended to the end of a request. 

- [ ] Requires https://github.com/openshift/ocm-container/pull/174 to be merged. 