### PR TITLE
show cluster context at login

### DIFF
--- a/utils/bashrc.d/99-osdctl-cluster-context.bashrc
+++ b/utils/bashrc.d/99-osdctl-cluster-context.bashrc
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# show cluster context at login
+
+if [ -n "$CLUSTER_ID" -a -z "$SKIP_CLUSTER_CONTEXT" ]; then
+	echo "Checking the context on $CLUSTER_ID"
+	osdctl cluster context "$CLUSTER_ID"
+fi


### PR DESCRIPTION
if the user is directly logging into a cluster, show the cluster context at login. you can disable it by setting the env var SKIP_CLUSTER_CONTEXT.