### PR TITLE
Update osdctl to v0.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,7 +164,7 @@ FROM builder as osdctl-builder
 # Add `osdctl` utility for common OSD commands
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
 # the URL_SLUG is for checking the releasenotes when a version updates
-ARG OSDCTL_VERSION="tags/v0.15.0"
+ARG OSDCTL_VERSION="tags/v0.16.0"
 ENV OSDCTL_URL_SLUG="openshift/osdctl"
 ENV OSDCTL_URL="https://api.github.com/repos/${OSDCTL_URL_SLUG}/releases/${OSDCTL_VERSION}"
 


### PR DESCRIPTION
Updates osdctl to version 0.16.0

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
