### PR TITLE
[OCPBUGS-14550] Update cluster-console image

### DIFF
--- a/utils/bin/cluster-console
+++ b/utils/bin/cluster-console
@@ -13,5 +13,6 @@ then
   exit 1
 fi
 
-exec ocm backplane console --port $OCM_BACKPLANE_CONSOLE_PORT  --image=quay.io/openshift/origin-console \
+# taislam_osd image is used as a temporary workaround until OCPBUGS-14550 is fixed 
+exec ocm backplane console --port $OCM_BACKPLANE_CONSOLE_PORT  --image=quay.io/taislam_osd/openshift-console \
   | sed "s/${OCM_BACKPLANE_CONSOLE_PORT}/$(cat /tmp/portmap)/"


### PR DESCRIPTION
taislam_osd image is used as a temporary workaround until OCPBUGS-14550 is fixed