### PR TITLE
Fix the prompt when using new backplane

### DIFF
--- a/utils/bashrc.d/06-sre-utils.bashrc
+++ b/utils/bashrc.d/06-sre-utils.bashrc
@@ -18,5 +18,9 @@ then
 fi
 
 function cluster_function() {
-  oc config view  --minify --output 'jsonpath={..server}' | cut -d. -f2-4
+  info="$(ocm backplane status 2> /dev/null)"
+  if [ $? -ne 0 ]; then return; fi
+  clustername=$(grep "Cluster Name" <<< $info | awk '{print $3}')
+  baseid=$(grep "Cluster Basedomain" <<< $info | awk '{print $3}' | cut -d'.' -f1,2)
+  echo $clustername.$baseid
 }


### PR DESCRIPTION
The api url is different with the new backplane so our old method of finding the cluster name does not work. This seems to fix it.
Shamelessly copied from https://github.com/openshift/backplane-cli/blob/main/docs/PS1-setup.md

Wait for #187 to be merged