### PR TITLE
Adds check for SSH_AUTH_SOCK

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -84,6 +84,11 @@ source ${OCM_CONTAINER_CONFIGFILE}
 ### SSH Agent Mounting
 operating_system=`uname`
 
+if [[ -z ${SSH_AUTH_SOCK} ]] ; then
+  echo "SSH_AUTH_SOCK is not set.  Are you trying to run ocm-container remotely?  Hint: Run 'eval \$(ssh-agent)' first."
+  exit 1
+fi
+
 SSH_AGENT_MOUNT="-v ${SSH_AUTH_SOCK}:/tmp/ssh.sock:ro"
 SSH_AUTH_SOCK_ENV="-e \"SSH_AUTH_SOCK=/tmp/ssh.sock\""
 


### PR DESCRIPTION
Checks that the SSH_AUTH_SOCK env variable is set, and prompts to run
ssh-agent if not.  This should have no effect on anyone running
ocm-container locally for the most part, and provide a friendly prompt
for folks running ocm-container via ssh to another machine.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
