### PR TITLE
add oc-elevate function

### DIFF
--- a/utils/bashrc.d/12-oc.bashrc
+++ b/utils/bashrc.d/12-oc.bashrc
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+oc-elevate() {
+  # set timeout and messaging
+  TIMEOUT="60"
+  PROMPT_TEXT="Enter justification for performed elevated action (${TIMEOUT}s timeout):"
+  NOOP_TEXT="No justification for elevated action was given exiting..."
+
+  # wait for user input 
+  read -t "${TIMEOUT}" -p "${PROMPT_TEXT}" REASON
+
+  # if reason is given run elevated action
+  if [[ ${REASON} ]]
+  then
+    ocm backplane elevate "${REASON[@]}" -- "$@"
+  else
+    # when reason is not given, show no op message
+    echo -e ${NOOP_TEXT} >&2
+  fi
+}


### PR DESCRIPTION
prompts for justification before commands as cluster admin

example when providing a justification:
```
[~ {production} (hive-xxx:default)]$ oc-elevate get pod -A -o json | jq -r '.items | length'
Enter justification for performed elevated action (60s timeout):test test
445
```

example when not providing a justification due to timeout or empty string
```
[~ {production} (hive-xxx::default)]$ oc-elevate get pod -A -o json | wc -l
Enter  justification for performed elevated action (60s timeout):
No justification for elevated action was given exiting...
0
```

Confirmed with security team, justification is sent to the audit log