### PR TITLE
add build targers for ci build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -328,8 +328,6 @@ RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "amd64" ]] && exit 
 RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "arm64" ]] && exit 0 || /bin/bash -c "curl -sSLf -O $(curl -sSLf ${K9S_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_arm64")) | .browser_download_url') "
 
 # Check the tarball and checksum match
-RUN ls -la
-RUN cat sha256sum.txt
 RUN bash -c 'sha256sum --check <( grep $(platform_convert "Linux_@@PLATFORM@@.tar.gz" --amd64 --arm64)  sha256sum.txt )'
 RUN tar --extract --gunzip --no-same-owner --directory /out k9s --file *.tar.gz
 RUN chmod +x /out/k9s

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,21 @@ registry-login:
 	@test "${REGISTRY_USER}" != "" && test "${REGISTRY_TOKEN}" != "" || (echo "REGISTRY_USER and REGISTRY_TOKEN must be defined" && exit 1)
 	@${CONTAINER_ENGINE} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" "$(IMAGE_REGISTRY)"
 
-.PHONY: tag-n-push
-tag-n-push:
+.PHONY: tag
+tag:
 	$(eval BUILD_ID=$(shell ${CONTAINER_ENGINE} image inspect --format '{{.ID}}' $(IMAGE_NAME) | cut -c1-12) )
 	${CONTAINER_ENGINE} tag $(IMAGE_NAME) $(IMAGE_URI):$(GIT_REVISION)-$(BUILD_ID)
 	${CONTAINER_ENGINE} tag $(IMAGE_NAME) $(IMAGE_URI):$(GIT_REVISION)
 	${CONTAINER_ENGINE} tag $(IMAGE_NAME) $(IMAGE_URI):latest
-	$(MAKE) registry-login
+
+.PHONY: push
+push:
 	${CONTAINER_ENGINE} push $(IMAGE_NAME) $(IMAGE_URI):$(GIT_REVISION)-$(BUILD_ID)
 	${CONTAINER_ENGINE} push $(IMAGE_NAME) $(IMAGE_URI):$(GIT_REVISION)
 	${CONTAINER_ENGINE} push $(IMAGE_NAME) $(IMAGE_URI):latest
+
+.PHONY: tag-n-push
+tag-n-push:
+	$(MAKE) tag
+	$(MAKE) registry-login
+	$(MAKE) push

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,4 @@ push:
 	${CONTAINER_ENGINE} push $(IMAGE_NAME) $(IMAGE_URI):latest
 
 .PHONY: tag-n-push
-tag-n-push:
-	$(MAKE) tag
-	$(MAKE) registry-login
-	$(MAKE) push
+tag-n-push: registry-login tag push

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+CONTAINER_ENGINE:=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+ifeq ($(CONTAINER_ENGINE),)
+ $(error ERROR: container engine not foumd, install podman or docker and run make again)
+endif
+
+REGISTRY_USER?=$(QUAY_USER)
+REGISTRY_TOKEN?=$(QUAY_TOKEN)
+
+IMAGE_REGISTRY?=quay.io
+IMAGE_REPOSITORY?=app-sre
+IMAGE_NAME?=ocm-container
+IMAGE_URI=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)
+GIT_REVISION=$(shell git rev-parse --short=7 HEAD)
+
 .PHONY: init
 init:
 	bash init.sh
@@ -5,3 +19,19 @@ init:
 .PHONY: build
 build:
 	bash build.sh
+
+.PHONY: registry-login
+registry-login:
+	@test "${REGISTRY_USER}" != "" && test "${REGISTRY_TOKEN}" != "" || (echo "REGISTRY_USER and REGISTRY_TOKEN must be defined" && exit 1)
+	@${CONTAINER_ENGINE} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" "$(IMAGE_REGISTRY)"
+
+.PHONY: tag-n-push
+tag-n-push:
+	$(eval BUILD_ID=$(shell ${CONTAINER_ENGINE} image inspect --format '{{.ID}}' $(IMAGE_NAME) | cut -c1-12) )
+	${CONTAINER_ENGINE} tag $(IMAGE_NAME) $(IMAGE_URI):$(GIT_REVISION)-$(BUILD_ID)
+	${CONTAINER_ENGINE} tag $(IMAGE_NAME) $(IMAGE_URI):$(GIT_REVISION)
+	${CONTAINER_ENGINE} tag $(IMAGE_NAME) $(IMAGE_URI):latest
+	$(MAKE) registry-login
+	${CONTAINER_ENGINE} push $(IMAGE_NAME) $(IMAGE_URI):$(GIT_REVISION)-$(BUILD_ID)
+	${CONTAINER_ENGINE} push $(IMAGE_NAME) $(IMAGE_URI):$(GIT_REVISION)
+	${CONTAINER_ENGINE} push $(IMAGE_NAME) $(IMAGE_URI):latest


### PR DESCRIPTION
results in images as seen from
```
$ podman images
REPOSITORY                                   TAG                   IMAGE ID      CREATED         SIZE
quay.io/app-sre/ocm-container                d5e96e5               f05761057397  2 minutes ago   2.87 GB
quay.io/app-sre/ocm-container                d5e96e5-f05761057397  f05761057397  2 minutes ago   2.87 GB
quay.io/app-sre/ocm-container                d5e96e5-f1f5ad53c42d  f1f5ad53c42d  9 minutes ago   2.87 GB
quay.io/app-sre/ocm-container                latest                1df22df2353c  12 minutes ago  2.87 GB
quay.io/app-sre/ocm-container                31d0dc8               1df22df2353c  12 minutes ago  2.87 GB
quay.io/app-sre/ocm-container                31d0dc8-1df22df2353c  1df22df2353c  12 minutes ago  2.87 GB
quay.io/app-sre/ocm-container                d5e96e5-1df22df2353c  1df22df2353c  12 minutes ago  2.87 GB
localhost/ocm-container                      latest                1df22df2353c  12 minutes ago  2.87 GB
```

tags correlate with the git commit hashes and unique build id's