### PR TITLE
Mount local certificate authority anchors

### DIFF
--- a/env.source.sample
+++ b/env.source.sample
@@ -64,3 +64,7 @@ here \
 ### In the case of a directory being defined, all *.sh files in that directory
 ### will be `source`'d.
 #export PERSONALIZATION_FILE=/home/myuser/path/to/my/defined-personalizations.sh
+
+### CA_SOURCE_ANCHORS
+### The CA_SOURCE_ANCHORS is a local trusted certificate authorities to mount and use in a container.
+#export CA_SOURCE_ANCHORS=/etc/pki/ca-trust/source/anchors

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -81,6 +81,13 @@ fi
 
 source ${OCM_CONTAINER_CONFIGFILE}
 
+### Mount certificate authority trust source to avoid self-signed certificate errors
+CA_SOURCE_ANCHORS=${CA_SOURCE_ANCHORS:-"/etc/pki/ca-trust/source/anchors"}
+if [[ -d "${CA_SOURCE_ANCHORS}" ]] && [[ -r "${CA_SOURCE_ANCHORS}" ]]
+then
+  CA_SOURCE_MOUNT="-v ${CA_SOURCE_ANCHORS}:/etc/pki/ca-trust/source/anchors:ro"
+fi
+
 ### SSH Agent Mounting
 operating_system=`uname`
 
@@ -98,6 +105,7 @@ if [ -d "${SSH_SOCKETS_DIR}" ] && [ "${DISABLE_SSH_MULTIPLEXING}" != "true" ]
 then
  SSH_SOCKETS_MOUNT="-v ${SSH_SOCKETS_DIR}:/root/.ssh/sockets"
 fi
+
 
 if [[ "$CONTAINER_SUBSYS" != "podman" ]] && [[  "$operating_system" == "Darwin" ]]
 then
@@ -248,6 +256,7 @@ ${JIRAFILEMOUNT} \
 ${PAGERDUTYFILEMOUNT} \
 ${OSDCTL_CONFIG_MOUNT} \
 ${AWSFILEMOUNT} \
+${CA_SOURCE_MOUNT} \
 ${SSH_AGENT_MOUNT} \
 ${SSH_SOCKETS_MOUNT} \
 ${SSH_AUTH_SOCK_ENV} \

--- a/utils/bashrc.d/03-ocm-container.bashrc
+++ b/utils/bashrc.d/03-ocm-container.bashrc
@@ -4,3 +4,6 @@ export OCM_URL=${OCM_URL:-production}
 
 ## Overwrite defaults with user-config
 source /root/.config/ocm-container/env.source
+
+## Extract mounted source CA's to /etc/pki/ca-trust/extracted
+update-ca-trust


### PR DESCRIPTION
Mounts certificate authority trust source to avoid self-signed certificate errors

before
```
$ curl https://someplace.redhat.com
curl: (60) SSL certificate problem: self-signed certificate in certificate chain
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

after
```
curl https://someplace.redhat.com
<html><body>You are being <a href="https://someplace.redhat.com/users/auth/geo/sign_in">redirected</a>.</body></html>```
```
