### PR TITLE
Add settings for repo and tag

### DIFF
--- a/env.source.sample
+++ b/env.source.sample
@@ -1,6 +1,12 @@
 ### Autodetect container subsystem
 export CONTAINER_SUBSYS=${CONTAINER_SUBSYS:-"$(which podman >/dev/null 2>&1 && echo podman || echo docker)"}
 
+### Set the container repo and tag we want to use.
+### Uncomment this to use the pre-built images Set it to localhost to use local images
+#export OCM_CONTAINER_REPO="quay.io/app-sre"
+### set this to the tag you wish to use
+export OCM_CONTAINER_TAG="latest"
+
 ### Select cli, options include:
 ### - "ocm"
 ### - "rosa"

--- a/env.source.sample
+++ b/env.source.sample
@@ -2,8 +2,9 @@
 export CONTAINER_SUBSYS=${CONTAINER_SUBSYS:-"$(which podman >/dev/null 2>&1 && echo podman || echo docker)"}
 
 ### Set the container repo and tag we want to use.
-### Uncomment this to use the pre-built images Set it to localhost to use local images
-#export OCM_CONTAINER_REPO="quay.io/app-sre"
+### Uncomment this to use local images
+### The default is repository `quay.io/app-sre`
+#export OCM_CONTAINER_REPO="localhost"
 ### set this to the tag you wish to use
 export OCM_CONTAINER_TAG="latest"
 

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -9,6 +9,7 @@ usage() {
   -h  --help          		Show this message and exit
   -n  --no-personalizations     Disables personalizations file, typically used for debugging potential issues or during automated script running
   -o  --launch-opts   		Sets extra non-default container launch options
+  -r  --repo                    Sets the container repository to use (We use quay.io/app-sre by default)
   -t  --tag           		Sets the image tag to use
   -x  --debug         		Set bash debug flag
 
@@ -46,6 +47,9 @@ while [ "$1" != "" ]; do
                                     ;;
     -t | --tag )                    shift
                                     BUILD_TAG="$1"
+                                    ;;
+    -r | --repo )                   shift
+                                    BUILD_REPO="$1"
                                     ;;
     -x | --debug )                  set -x
                                     ;;

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -17,16 +17,8 @@ EOF
 }
 
 ARGS=()
-if [[ -n "${OCM_CONTAINER_TAG}" ]]; then
-  BUILD_TAG="${OCM_CONTAINER_TAG}"
-else
-  BUILD_TAG="latest"
-fi
-if [[ -n "${OCM_CONTAINER_REPO}" ]]; then
-  BUILD_REPO="${OCM_CONTAINER_REPO}"
-else
-  BUILD_REPO="localhost"
-fi
+BUILD_TAG="${OCM_CONTAINER_TAG:=latest}"
+BUILD_REPO="${OCM_CONTAINER_REPO:=quay.io/app-sre}"
 EXEC_SCRIPT=
 TTY="-it"
 ENABLE_PERSONALIZATION_MOUNT=true

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -256,7 +256,7 @@ then
   fi
 fi
 
-echo "using tag ${BUILD_REPO}/ocm-container/${BUILD_TAG}"
+echo "using tag ${BUILD_REPO}/ocm-container:${BUILD_TAG}"
 
 ### start container
 CONTAINER=$(${CONTAINER_SUBSYS} create $TTY --rm --privileged \

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -17,7 +17,16 @@ EOF
 }
 
 ARGS=()
-BUILD_TAG="latest"
+if [[ -n "${OCM_CONTAINER_TAG}" ]]; then
+  BUILD_TAG="${OCM_CONTAINER_TAG}"
+else
+  BUILD_TAG="latest"
+fi
+if [[ -n "${OCM_CONTAINER_REPO}" ]]; then
+  BUILD_REPO="${OCM_CONTAINER_REPO}"
+else
+  BUILD_REPO="localhost"
+fi
 EXEC_SCRIPT=
 TTY="-it"
 ENABLE_PERSONALIZATION_MOUNT=true
@@ -251,6 +260,8 @@ then
   fi
 fi
 
+echo "using tag ${BUILD_REPO}/ocm-container/${BUILD_TAG}"
+
 ### start container
 CONTAINER=$(${CONTAINER_SUBSYS} create $TTY --rm --privileged \
 -e "OCM_URL" \
@@ -275,7 +286,7 @@ ${PORT_MAP_OPTS} \
 ${OCM_CONTAINER_LAUNCH_OPTS} \
 ${PERSONALIZATION_MOUNT} \
 ${BACKPLANE_CONFIG_MOUNT} \
-ocm-container:${BUILD_TAG} ${EXEC_SCRIPT})
+${BUILD_REPO}/ocm-container:${BUILD_TAG} ${EXEC_SCRIPT})
 
 $CONTAINER_SUBSYS start $CONTAINER > /dev/null
 


### PR DESCRIPTION
Adding an way to configure which repo to use and an extra way to set tag using env vars

I have been using direnv as a way to set tag and repo for ocm-container this method will also work with env.source so I thought I would share it.
We currently don't have a way to configure which repo to use so this will aslo allow us to use the pre-built images on quay.