### PR TITLE
Fix the builder for oc-nodepp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -348,12 +348,12 @@ RUN /bin/bash -c "curl -sSLf $(curl -sSLf ${NODEPP_URL} -o - | jq -r '.assets[] 
 
 # Download the binary tarball
 ## x86-native
-RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "amd64" ]] && exit 0 || /bin/bash -c "curl -sSLf -O $(curl -sSLf ${NODEPP_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_amd64")) | .browser_download_url') "
+RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "amd64" ]] && exit 0 || /bin/bash -c "curl -sSLf -O $(curl -sSLf ${NODEPP_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_x86_64")) | .browser_download_url') "
 # arm-native
 RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "arm64" ]] && exit 0 || /bin/bash -c "curl -sSLf -O $(curl -sSLf ${NODEPP_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_arm64")) | .browser_download_url') "
 
 # Check the tarball and checksum match
-RUN bash -c 'sha256sum --check <( grep $(platform_convert "Linux_@@PLATFORM@@.tar.gz" --amd64 --arm64)  sha256sum.txt )'
+RUN bash -c 'sha256sum --check <( grep $(platform_convert "Linux_@@PLATFORM@@.tar.gz" --x86_64 --arm64)  sha256sum.txt )'
 RUN tar --extract --gunzip --no-same-owner --directory /out oc-nodepp --file *.tar.gz
 RUN chmod +x /out/oc-nodepp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -336,7 +336,7 @@ FROM builder as oc-nodepp-builder
 # Add `oc-nodepp` utility
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
 # the URL_SLUG is for checking the releasenotes when a version updates
-ARG NODEPP_VERSION="v0.1.1"
+ARG NODEPP_VERSION="tags/v0.1.1"
 ENV NODEPP_URL_SLUG="mrbarge/oc-nodepp"
 ENV NODEPP_URL="https://api.github.com/repos/${NODEPP_URL_SLUG}/releases/${NODEPP_VERSION}"
 # Install oc-nodepp

--- a/Dockerfile
+++ b/Dockerfile
@@ -336,7 +336,7 @@ FROM builder as oc-nodepp-builder
 # Add `oc-nodepp` utility
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
 # the URL_SLUG is for checking the releasenotes when a version updates
-ARG NODEPP_VERSION="tags/v0.1.1"
+ARG NODEPP_VERSION="tags/v0.1.2"
 ENV NODEPP_URL_SLUG="mrbarge/oc-nodepp"
 ENV NODEPP_URL="https://api.github.com/repos/${NODEPP_URL_SLUG}/releases/${NODEPP_VERSION}"
 # Install oc-nodepp


### PR DESCRIPTION
The builder for container for oc-nodepp was using the wrong URL. This fixes that.
Thanks @xiaoyu74