### PR TITLE
Update backplane-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -358,7 +358,7 @@ RUN tar --extract --gunzip --no-same-owner --directory /out oc-nodepp --file *.t
 RUN chmod +x /out/oc-nodepp
 
 FROM builder as backplane-builder
-ARG BACKPLANE_VERSION="tags/v0.1.10"
+ARG _VERSION="tags/v0.1.11"
 ENV BACKPLANE_URL_SLUG="openshift/backplane-cli"
 ENV BACKPLANE_URL="https://api.github.com/repos/${BACKPLANE_URL_SLUG}/releases/${BACKPLANE_VERSION}"
 WORKDIR /backplane


### PR DESCRIPTION
fixes warning  Your Backplane CLI is not up to date. Please run the command 'ocm backplane upgrade' to upgrade to the latest version  Current version=0.1.10 Latest version=0.1.11