### PR TITLE
add dig utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN microdnf --assumeyes --nodocs install \
       podman \
       fuse-overlayfs \
       crun\
+      bind-utils \
       && microdnf clean all \
       && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Since we're doing so much network diagnosis, having more network tools built into ocm-container is useful. This commit adds dig via the bind-utils package