### PR TITLE
Adds the ability to provide the JIRA auth via env vars

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -140,6 +140,9 @@ fi
 if [ -f ${HOME}/${JIRA_CONFIG_DIR}/token.json ]
 then
   JIRATOKENCONFIG="-e JIRA_API_TOKEN=$(jq -r .token ${HOME}/${JIRA_CONFIG_DIR}/token.json) -e JIRA_AUTH_TYPE=bearer"
+elif [ -n $JIRA_API_TOKEN ] && [ -n $JIRA_AUTH_TYPE ]
+then
+  JIRATOKENCONFIG="-e JIRA_API_TOKEN -e JIRA_AUTH_TYPE"
 fi
 
 ### PagerDuty Token Mounting


### PR DESCRIPTION
I already had the env vars set and don't have them available in a token file, so I added the ability to fallback to the env vars if they're already set.

These could also in theory be set to .env.source as well, but it allows for both.