### PR TITLE
Update OWNERS file to most active committers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,18 @@
 reviewers:
 - AlexVulaj
-- drewandersonnz
-- iamkirkbater
 - clcollins
-- rogbas
+- iamkirkbater
+- rendhalver
+- T0MASD
 approvers:
-- drewandersonnz
-- iamkirkbater
+- AlexVulaj
 - clcollins
-- rogbas
+- iamkirkbater
+- rendhalver
+- T0MASD
 maintainers:
-- drewandersonnz
-- iamkirkbater
+- AlexVulaj
 - clcollins
-- rogbas
+- iamkirkbater
+- rendhalver
+- T0MASD


### PR DESCRIPTION
Updates the OWNERS file to include the folks who are most active in
maintaining ocm-container

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
