### PR TITLE
backplane tools builder

### DIFF
--- a/utils/bin/aws
+++ b/utils/bin/aws
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set \
+  -o nounset \
+  -o pipefail \
+  -o errexit
+export HTTPS_PROXY=squid.corp.redhat.com:3128
+export HTTP_PROXY=squid.corp.redhat.com:3128
+exec /usr/local/aws-cli/aws "$@"


### PR DESCRIPTION
adds building backplane tools as a separate step and explicitly copies the binaries. One weird thing with aws-cli :man_facepalming: is that it's weird python code with linking to c library so I follow aws install instructions placing that whole mess to /usr/local/aws-cli, in addition we also use a wrapper that sets proxy for aws cli hence the script in bashrc.d 
this fixes issue brought up in  https://github.com/openshift/ocm-container/pull/236  