### PR TITLE
handle better ocm-container config file creation

### DIFF
--- a/env.source.sample
+++ b/env.source.sample
@@ -24,11 +24,7 @@ export OCM_USER=${OCM_USER:-your_user}
 ### Your ocm Offline Access Token from
 ###     https://cloud.redhat.com/openshift/token
 # REQUIRED: change this env to offline token
-export OFFLINE_ACCESS_TOKEN="\
-your \
-token \
-here \
-"
+export OFFLINE_ACCESS_TOKEN="YOUR_TOKEN_HERE"
 
 ### OPS_UTILS_DIR
 ### The OPS_UTILS_DIR setting is an absolute path to any necessary scripts you wish

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -74,9 +74,19 @@ export OCM_CONTAINER_CONFIGFILE="$CONFIG_DIR/env.source"
 
 if [ ! -f ${OCM_CONTAINER_CONFIGFILE} ]; then
     echo "Cannot find config file at $OCM_CONTAINER_CONFIGFILE";
-    echo "Run the init.sh file to create one."
-    echo "exiting"
-    exit 1;
+    echo "Downloading sample config from upstream..."
+    mkdir -p ${CONFIG_DIR}
+    curl -s https://raw.githubusercontent.com/openshift/ocm-container/master/env.source.sample --output ${OCM_CONTAINER_CONFIGFILE}
+    read -t 300 -p 'Paste your ocm token from https://cloud.redhat.com/openshift/token: ' CONFIG_OCM_TOKEN
+    if [[ $? -gt 128 ]]
+    then
+      echo -e "\nTimeout waiting for ocm token"
+      rm ${OCM_CONTAINER_CONFIGFILE}
+      exit 1
+    else
+      echo "Thanks, updating the sample config..."
+      sed -i "s/YOUR_TOKEN_HERE/${CONFIG_OCM_TOKEN}/g" ${OCM_CONTAINER_CONFIGFILE}
+    fi
 fi
 
 source ${OCM_CONTAINER_CONFIGFILE}


### PR DESCRIPTION
when config not found, download one from upstream, promt for ocm token for 5min, if provided, update it and continue as normal

```
[tomas@ugnis ocm-container]$ rm ~/.config/ocm-container/env.source 
[tomas@ugnis ocm-container]$ ./ocm-container.sh 
Cannot find config file at /home/tomas/.config/ocm-container/env.source
Downloading sample config from upstream...
Paste your ocm token from https://cloud.redhat.com/openshift/token: dummy token ftw
Thanks, updating the sample config...
```
so the token is saved
```
[tomas@ugnis ocm-container]$ grep TOKEN ~/.config/ocm-container/env.source 
export OFFLINE_ACCESS_TOKEN="dummy token ftw"
```