### PR TITLE
Containerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -277,6 +277,9 @@ ARG PAGERDUTY_VERSION="0.1.18"
 ENV HOME=/root
 RUN npm install -g pagerduty-cli@${PAGERDUTY_VERSION}
 
+# install ssm plugin
+RUN rpm -i $(platform_convert https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_@@PLATFORM@@/session-manager-plugin.rpm --arm64 --custom-amd64 64bit)
+
 # Setup bashrc.d directory
 # Files with a ".bashrc" extension are sourced on login
 COPY utils/bashrc.d /root/.bashrc.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -261,10 +261,8 @@ RUN yq --version
 RUN k9s completion bash > /etc/bash_completion.d/k9s
 RUN ocm backplane version
 RUN ocm backplane completion bash > /etc/bash_completion.d/ocm-backplane
-RUN hypershift --version
-
-# rosa is only available for amd64 platforms so ignore it
-RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "amd64" ]] && rm ${BIN_DIR}/rosa || rosa completion bash > /etc/bash_completion.d/rosa
+RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "amd64" ]] && echo "removing non-arm64 hypershift binary" && rm ${BIN_DIR}/hypershift || hypershift --version
+RUN rosa completion bash > /etc/bash_completion.d/rosa
 
 # Install utils
 COPY utils/bin /root/.local/bin

--- a/utils/dockerfile_assets/platforms.sh
+++ b/utils/dockerfile_assets/platforms.sh
@@ -10,11 +10,13 @@ usage() {
   requires one of each of the x86 arch options below and arm arch options below.
 
   ARMARCH Options:
-  --arm64    target arm64 binary for arm arch
-  --aarch64  target aarch64 binary for arm arch
+  --arm64                 target arm64 binary for arm arch
+  --aarch64               target aarch64 binary for arm arch
+  --custom-arm64 string   target arm64 string
   X86ARCH Options:
-  --amd64    target amd64 binary for x86 arch
-  --x86_64   target x86_64 binary for x86 arch
+  --amd64                 target amd64 binary for x86 arch
+  --x86_64                target x86_64 binary for x86 arch
+  --custom-amd64 string   target x86_64 string
   Additonal Options:
   -v | --verbose    Enables more verbose output
   -i | --file       Replaces all instances of "@@PLATFORM@@" in a file, rewriting the file
@@ -40,6 +42,12 @@ while [ "$1" != "" ]; do
     --amd64 )           X86ARCH=amd64
                         ;;
     --x86_64 )          X86ARCH=x86_64
+                        ;;
+    --custom-arm64)     shift
+                        ARMARCH=$1
+                        ;;
+    --custom-amd64)     shift
+                        X86ARCH=$1
                         ;;
     -i | --file )       shift
                         REPLACEFILE=$1


### PR DESCRIPTION
* ROSA cli now has an arm64 build, so let's run the completion bash
* Hypershift CLI tool does NOT have an arm64 build, so we remove it from the container so this builds on arm64
* Install the session manager plugin for the aws CLI
* Updates the platform_convert script to work with a custom `64bit` tag for the aws linux ssm plugin rpm url.