### PR TITLE
Fixes k9s build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,12 +159,12 @@ RUN /bin/bash -c "curl -sSLf $(curl -sSLf ${K9S_URL} -o - | jq -r '.assets[] | s
 
 # Download the binary tarball
 # x86-native
-RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "amd64" ]] && exit 0 || /bin/bash -c "curl -sSLf -O $(curl -sSLf ${K9S_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_amd64")) | .browser_download_url') "
+RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "amd64" ]] && exit 0 || /bin/bash -c "curl -sSLf -O $(curl -sSLf ${K9S_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_amd64.tar.gz$")) | .browser_download_url')"
 # arm-native
-RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "arm64" ]] && exit 0 || /bin/bash -c "curl -sSLf -O $(curl -sSLf ${K9S_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_arm64")) | .browser_download_url') "
+RUN [[ $(platform_convert "@@PLATFORM@@" --amd64 --arm64) != "arm64" ]] && exit 0 || /bin/bash -c "curl -sSLf -O $(curl -sSLf ${K9S_URL} -o - | jq -r '.assets[] | select(.name|test("Linux_arm64.tar.gz$")) | .browser_download_url')"
 
 # Check the tarball and checksum match
-RUN bash -c 'sha256sum --check <( grep $(platform_convert "Linux_@@PLATFORM@@.tar.gz" --amd64 --arm64)  sha256sum.txt )'
+RUN bash -c 'sha256sum --check <( grep $(platform_convert "Linux_@@PLATFORM@@.tar.gz$" --amd64 --arm64)  sha256sum.txt )'
 RUN tar --extract --gunzip --no-same-owner --directory /out k9s --file *.tar.gz
 RUN chmod +x /out/k9s
 


### PR DESCRIPTION
Targets just the k9s tar.gz file and drops the .sbom filename that was getting snagged by the curl call as well.

If you're attempting to try this on an arm64 machine you'll need to pull #245 first to get the hypershift fix as well otherwise it won't build.  Regular x86_64 machines should build this with no issue.