### PR TITLE
Create backplane config if missing

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -234,22 +234,57 @@ then
   fi
 fi
 
-## Check for backplane config dir override and then mount the directory if it exists
+## Check for backplane config dir override
 if [ -z "$BACKPLANE_CONFIG_DIR" ]
 then
   BACKPLANE_CONFIG_DIR=$DEFAULT_BACKPLANE_CONFIG_DIR_LOCATION
 fi
-
-if [ -d "$BACKPLANE_CONFIG_DIR" ]
+## Set ocm url
+if [ -z $OCM_URL ]
 then
-  BACKPLANE_CONFIG_MOUNT="-v $BACKPLANE_CONFIG_DIR:/root/.config/backplane:ro"
-  if [ -z $OCM_URL ] || [ $OCM_URL == "production" ]
-  then
-    BACKPLANE_CONFIG_MOUNT="$BACKPLANE_CONFIG_MOUNT -e BACKPLANE_CONFIG=/root/.config/backplane/config.json"
-  else
-    BACKPLANE_CONFIG_MOUNT="$BACKPLANE_CONFIG_MOUNT -e BACKPLANE_CONFIG=/root/.config/backplane/config.$OCM_URL.json"
-  fi
+  OCM_URL="production"
 fi
+## Set the mount path
+BACKPLANE_CONFIG_MOUNT="-v $BACKPLANE_CONFIG_DIR:/root/.config/backplane:ro"
+## Set backplane config env var based on the environment
+if [ $OCM_URL == "production" ]
+then
+  BACKPLANE_CONFIG="config.json"
+else
+  BACKPLANE_CONFIG="config.$OCM_URL.json"
+fi
+## Create backplane config if missing
+if [ ! -f $BACKPLANE_CONFIG_DIR/$BACKPLANE_CONFIG ]; then
+    echo "Cannot find backplane config file at $BACKPLANE_CONFIG_DIR/$BACKPLANE_CONFIG";
+    echo "Setting up backplane config for ${OCM_URL}..."
+    read -t 300 -p 'proxy-url: ' BACKPLANE_CONFIG_PROXY_URL
+    if [[ $? -gt 128 ]]
+    then
+      echo -e "\nTimeout waiting for backplane proxy url"
+      exit 1
+    fi
+    read -t 300 -p 'assume-initial-arn: ' BACKPLANE_CONFIG_ASSUME_ARN
+    if [[ $? -gt 128 ]]
+    then
+      echo -e "\nTimeout waiting for assume initial arn"
+      exit 1
+    fi
+    ## Ensure backplane conf dir exits
+    if [ ! -d "$BACKPLANE_CONFIG_DIR" ]
+    then
+      mkdir -p $BACKPLANE_CONFIG_DIR
+    fi
+    ## Create backplane configuration
+    cat << EOF > $BACKPLANE_CONFIG_DIR/$BACKPLANE_CONFIG
+{
+    "assume-initial-arn": "${BACKPLANE_CONFIG_ASSUME_ARN}",
+    "proxy-url": "${BACKPLANE_CONFIG_PROXY_URL}",
+    "session-dir": "~/.config/backplane/session",
+}
+EOF
+  fi
+# Export BACKPLANE_CONFIG var inside the container
+BACKPLANE_CONFIG_MOUNT="$BACKPLANE_CONFIG_MOUNT -e BACKPLANE_CONFIG=/root/.config/backplane/${BACKPLANE_CONFIG}"
 
 ### start container
 CONTAINER=$(${CONTAINER_SUBSYS} create $TTY --rm --privileged \


### PR DESCRIPTION
```
$ ocm-container
Cannot find backplane config file at /home/tomas/.config/backplane/config.json
Setting up backplane config for production...
backplane url: https://api.integration....
proxy-url: http://squid....
assume-initial-arn: arn:aws:iam::...
[~ {production} ]$ exit

$ ocm-container-stg 
Cannot find backplane config file at /home/tomas/.config/backplane/config.stg.json
Setting up backplane config for stg...
backplane url: https://api.integration....
proxy-url: http://squid....
assume-initial-arn: arn:aws:iam::...
[~ {stg} ]$ exit

$ ocm-container-int 
Cannot find backplane config file at /home/tomas/.config/backplane/config.int.json
Setting up backplane config for int...
backplane url: https://api.integration....
proxy-url: http://squid....
assume-initial-arn: arn:aws:iam::...
[~ {int} ]$ exit
```