### PR TITLE
Adds extra build configuration to allow building multiple architectures

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -2,6 +2,7 @@
 
 set -eo pipefail
 
+NOCACHE=""
 while [ "$1" != "" ]; do
   case $1 in
     -n | --no-cache )       NOCACHE="--no-cache "
@@ -12,6 +13,9 @@ while [ "$1" != "" ]; do
   esac
   shift
 done
+
+# set this here so that we can allow the argument parsing above
+set -u
 
 build_cmds=(
   "bash build.sh -t latest-arm64 $NOCACHE -- '--platform=linux/arm64'"
@@ -26,7 +30,7 @@ then
     echo "echo '$cmd' && $cmd && echo && echo '-----'"
   done) | parallel
 else
-  for cmd in "{build_cmds[@]}"
+  for cmd in "${build_cmds[@]}"
   do
     eval "$cmd"
     echo

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+build_cmds=(
+  "bash build.sh -t latest-arm64 -- '--platform=linux/arm64'"
+  "bash build.sh -t latest-amd64 -- '--platform=linux/amd64'"
+)
+
+if command -v parallel &> /dev/null
+then
+  (for cmd in "${build_cmds[@]}"
+  do
+    echo "echo '$cmd' && $cmd && echo && echo '-----'"
+  done) | parallel
+else
+  for cmd in "{build_cmds[@]}"
+  do
+    eval "$cmd"
+    echo
+    echo "----"
+    echo
+  done
+fi
+
+

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 
+while [ "$1" != "" ]; do
+  case $1 in
+    -n | --no-cache )       NOCACHE="--no-cache "
+                            ;;
+    * ) echo "Unexpected parameter $1"
+        usage
+        exit 1
+  esac
+  shift
+done
+
 build_cmds=(
-  "bash build.sh -t latest-arm64 -- '--platform=linux/arm64'"
-  "bash build.sh -t latest-amd64 -- '--platform=linux/amd64'"
+  "bash build.sh -t latest-arm64 $NOCACHE -- '--platform=linux/arm64'"
+  "bash build.sh -t latest-amd64 $NOCACHE -- '--platform=linux/amd64'"
 )
 
 if command -v parallel &> /dev/null
 then
+  echo "Running with GNU Parallel. No output will appear until the subprocess has finished."
   (for cmd in "${build_cmds[@]}"
   do
     echo "echo '$cmd' && $cmd && echo && echo '-----'"
@@ -20,5 +32,3 @@ else
     echo
   done
 fi
-
-

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 while [ "$1" != "" ]; do
   case $1 in
     -n | --no-cache )       NOCACHE="--no-cache "

--- a/.ci/pull-request-check.sh
+++ b/.ci/pull-request-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -euo pipefail
 
 # Build the images
 ./.ci/build.sh

--- a/.ci/pull-request-check.sh
+++ b/.ci/pull-request-check.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Build the images
+./.ci/build.sh
+
+make TAG=latest-amd64 ARCHITECTURE=amd64 tag
+make TAG=latest-arm64 ARCHITECTURE=arm64 tag

--- a/.ci/pull-request-check.sh
+++ b/.ci/pull-request-check.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 # Build the images
 ./.ci/build.sh
 

--- a/.ci/release-build.sh
+++ b/.ci/release-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -euo pipefail
 
 # Build the images
 ./.ci/build.sh

--- a/.ci/release-build.sh
+++ b/.ci/release-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Build the images
+./.ci/build.sh
+
+make TAG=latest-amd64 ARCHITECTURE=amd64 tag
+make TAG=latest-arm64 ARCHITECTURE=arm64 tag
+
+make TAG=latest-amd64 ARCHITECTURE=amd64 push
+make TAG=latest-arm64 ARCHITECTURE=arm64 push
+
+make build-manifest
+make push-manifest

--- a/.ci/release-build.sh
+++ b/.ci/release-build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 # Build the images
 ./.ci/build.sh
 

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ usage() {
   usage: $0 [ OPTIONS ] [ -- Additional Docker Build Options ]
   Options
   -h  --help      Show this message and exit
+  -n  --no-cache  Do not use the container runtime cache for images
   -t  --tag       Build with a specific docker tag
   -x  --debug     Set the bash debug flag
 
@@ -22,6 +23,8 @@ while [ "$1" != "" ]; do
   case $1 in
     -h | --help )           usage
                             exit 1
+                            ;;
+    -n | --no-cache )       NOCACHE="--no-cache "
                             ;;
     -t | --tag )            shift
                             BUILD_TAG=$1
@@ -70,7 +73,7 @@ date
 date -u
 
 # we want the $@ args here to be re-split
-time ${CONTAINER_SUBSYS} build \
+time ${CONTAINER_SUBSYS} build $NOCACHE\
   $CONTAINER_ARGS \
   -t ocm-container:${BUILD_TAG} .
 


### PR DESCRIPTION
Adds additional configuration to build for multiple architectures.

I _tried_ to add the functionality while keeping the original make targets like `make build` work the same as they do now for those who may be using those.

I highly recommend installing GNU `parallel` in order to build both at the same time. It takes ~20m to build amd64 on an arm64 laptop, FWIW.

Steps to test: (change IMAGE_REPOSITORY to your quay.io repo)

* `./.ci/build.sh`
* `make IMAGE_REPOSITORY=kbater TAG=latest-arm64 ARCHITECTURE=arm64 tag`
* `make IMAGE_REPOSITORY=kbater TAG=latest-amd64 ARCHITECTURE=amd64 tag`
* `make IMAGE_REPOSITORY=kbater TAG=latest-amd64 ARCHITECTURE=amd64 push`
* `make IMAGE_REPOSITORY=kbater TAG=latest-arm64 ARCHITECTURE=arm64 push`
* `make IMAGE_REPOSITORY=kbater build-manifest`
* `make IMAGE_REPOSITORY=kbater push-manifest`
* `podman manifest inspect quay.io/kbater/ocm-container:latest` and validate that you see the two different architectures.