### PR TITLE
adds buildx command to docker multi-platform builds

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -exo pipefail
 
 NOCACHE=""
 while [ "$1" != "" ]; do
@@ -18,8 +18,8 @@ done
 set -u
 
 build_cmds=(
-  "bash build.sh -t latest-arm64 $NOCACHE -- '--platform=linux/arm64'"
-  "bash build.sh -t latest-amd64 $NOCACHE -- '--platform=linux/amd64'"
+  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE"
+  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE"
 )
 
 if command -v parallel &> /dev/null

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -18,8 +18,8 @@ done
 set -u
 
 build_cmds=(
-  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE --build-arg GITHUB_URL=github-mirror.devshift.net"
-  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE --build-arg GITHUB_URL=github-mirror.devshift.net"
+  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE -- \"--build-arg GITHUB_URL=github-mirror.devshift.net\""
+  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE -- \"--build-arg GITHUB_URL=github-mirror.devshift.net\""
 )
 
 if command -v parallel &> /dev/null

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -18,8 +18,8 @@ done
 set -u
 
 build_cmds=(
-  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE -- '--github-mirror github-mirror.devshift.net'"
-  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE --github-mirror github-mirror.devshift.net'"
+  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE --github-mirror github-mirror.devshift.net"
+  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE --github-mirror github-mirror.devshift.net"
 )
 
 if command -v parallel &> /dev/null

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -18,8 +18,8 @@ done
 set -u
 
 build_cmds=(
-  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE -- '--build-arg GITHUB_URL=github-mirror.devshift.net'"
-  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE -- '--build-arg GITHUB_URL=github-mirror.devshift.net'"
+  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE -- '--github-mirror github-mirror.devshift.net'"
+  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE --github-mirror github-mirror.devshift.net'"
 )
 
 if command -v parallel &> /dev/null

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -18,8 +18,8 @@ done
 set -u
 
 build_cmds=(
-  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE -- \"--build-arg GITHUB_URL=github-mirror.devshift.net\""
-  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE -- \"--build-arg GITHUB_URL=github-mirror.devshift.net\""
+  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE -- '--build-arg GITHUB_URL=github-mirror.devshift.net'"
+  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE -- '--build-arg GITHUB_URL=github-mirror.devshift.net'"
 )
 
 if command -v parallel &> /dev/null

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -18,8 +18,8 @@ done
 set -u
 
 build_cmds=(
-  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE"
-  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE"
+  "bash build.sh -t latest-arm64 --platform linux/arm64 $NOCACHE --build-arg GITHUB_URL=github-mirror.devshift.net"
+  "bash build.sh -t latest-amd64 --platform linux/amd64 $NOCACHE --build-arg GITHUB_URL=github-mirror.devshift.net"
 )
 
 if command -v parallel &> /dev/null

--- a/.ci/pull-request-check.sh
+++ b/.ci/pull-request-check.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Build the images
-./.ci/build.sh
+./.ci/build.sh --no-cache
 
 make TAG=latest-amd64 ARCHITECTURE=amd64 tag
 make TAG=latest-arm64 ARCHITECTURE=arm64 tag

--- a/.ci/release-build.sh
+++ b/.ci/release-build.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Build the images
-./.ci/build.sh
+./.ci/build.sh --no-cache
 
 make TAG=latest-amd64 ARCHITECTURE=amd64 tag
 make TAG=latest-arm64 ARCHITECTURE=arm64 tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ COPY utils/dockerfile_assets/containers.conf /etc/containers/containers.conf
 # Anything in this image must be COPY'd into the final image, below
 FROM ${BASE_IMAGE} as builder
 
+ARG GITHUB_URL="api.github.com"
+
 # Adds Platform Conversion Tool for arm64/x86_64 compatibility
 # need to add this a second time to add it to the builder image
 COPY utils/dockerfile_assets/platforms.sh /usr/local/bin/platform_convert
@@ -99,14 +101,16 @@ FROM builder as omc-builder
 # Add `omc` utility to inspect must-gathers easily with 'oc' like commands
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
 # the URL_SLUG is for checking the releasenotes when a version updates
+ARG GITHUB_URL
 ARG OMC_VERSION="tags/v3.3.2"
 ENV OMC_URL_SLUG="gmeghnag/omc"
-ENV OMC_URL="https://api.github.com/repos/${OMC_URL_SLUG}/releases/${OMC_VERSION}"
+ENV OMC_URL="https://${GITHUB_URL}/repos/${OMC_URL_SLUG}/releases/${OMC_VERSION}"
 
 # Install omc
 RUN mkdir /omc
 WORKDIR /omc
 # Download the checksum
+RUN /bin/bash -c "echo ${OMC_URL}"
 RUN /bin/bash -c "curl -sSLf $(curl -sSLf ${OMC_URL} -o - | jq -r '.assets[] | select(.name|test("checksums.txt")) | .browser_download_url') -o md5sum.txt"
 
 # Download the binary
@@ -124,9 +128,10 @@ FROM builder as jira-builder
 # Add `jira` utility for working with OHSS tickets
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
 # the URL_SLUG is for checking the releasenotes when a version updates
+ARG GITHUB_URL
 ARG JIRA_VERSION="tags/v1.4.0"
 ENV JIRA_URL_SLUG="ankitpokhrel/jira-cli"
-ENV JIRA_URL="https://api.github.com/repos/${JIRA_URL_SLUG}/releases/${JIRA_VERSION}"
+ENV JIRA_URL="https://${GITHUB_URL}/repos/${JIRA_URL_SLUG}/releases/${JIRA_VERSION}"
 WORKDIR /jira
 # Download the checksum
 RUN /bin/bash -c "curl -sSLf $(curl -sSLf ${JIRA_URL} -o - | jq -r '.assets[] | select(.name|test("checksums.txt")) | .browser_download_url') -o checksums.txt"
@@ -147,9 +152,10 @@ FROM builder as k9s-builder
 # Add `k9s` utility
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
 # the URL_SLUG is for checking the releasenotes when a version updates
+ARG GITHUB_URL
 ARG K9S_VERSION="latest"
 ENV K9S_URL_SLUG="derailed/k9s"
-ENV K9S_URL="https://api.github.com/repos/${K9S_URL_SLUG}/releases/${K9S_VERSION}"
+ENV K9S_URL="https://${GITHUB_URL}/repos/${K9S_URL_SLUG}/releases/${K9S_VERSION}"
 
 # Install k9s
 RUN mkdir /k9s
@@ -173,9 +179,10 @@ FROM builder as oc-nodepp-builder
 # Add `oc-nodepp` utility
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
 # the URL_SLUG is for checking the releasenotes when a version updates
+ARG GITHUB_URL
 ARG NODEPP_VERSION="tags/v0.1.2"
 ENV NODEPP_URL_SLUG="mrbarge/oc-nodepp"
-ENV NODEPP_URL="https://api.github.com/repos/${NODEPP_URL_SLUG}/releases/${NODEPP_VERSION}"
+ENV NODEPP_URL="https://${GITHUB_URL}/repos/${NODEPP_URL_SLUG}/releases/${NODEPP_VERSION}"
 # Install oc-nodepp
 RUN mkdir /nodepp
 WORKDIR /nodepp
@@ -196,9 +203,10 @@ RUN chmod +x /out/oc-nodepp
 
 FROM builder as backplane-tools-builder
 # Install via backplane-tools
+ARG GITHUB_URL
 ARG BACKPLANE_TOOLS_VERSION="tags/v0.4.0"
 ENV BACKPLANE_TOOLS_URL_SLUG="openshift/backplane-tools"
-ENV BACKPLANE_TOOLS_URL="https://api.github.com/repos/${BACKPLANE_TOOLS_URL_SLUG}/releases/${BACKPLANE_TOOLS_VERSION}"
+ENV BACKPLANE_TOOLS_URL="https://${GITHUB_URL}/repos/${BACKPLANE_TOOLS_URL_SLUG}/releases/${BACKPLANE_TOOLS_VERSION}"
 RUN mkdir /backplane-tools
 WORKDIR /backplane-tools
 

--- a/build.sh
+++ b/build.sh
@@ -78,19 +78,6 @@ PLATFORM_BUILD_ARG="build"
 ### Start multi-platform build handling
 if [[ -n $PLATFORM ]] 
 then
-  #arch="$(echo $PLATFORM | cut -d/ -f2)"
-  #system_arch=""
-  #case "$(uname -m)" in
-  #  aarch64) system_arch="arm64";;
-  #  armv8b) system_arch="arm64";;
-  #  armv8l) system_arch="arm64";;
-  #  arm64) system_arch="arm64";;
-  #  amd64) system_arch="amd64";;
-  #  x86_64) system_arch="amd64";;
-  #  * ) echo "Unexpected system architecture: $(uname -m); exiting"; exit 228;;
-  #esac
-
-  #if [[ "$arch" != "$system_arch" ]] && [[ "${CONTAINER_SUBSYS}" == "docker" ]]
   if [[ "$CONTAINER_SUBSYS" == "docker" ]]
   then
     PLATFORM_BUILD_ARG="buildx build --platform=$PLATFORM"

--- a/build.sh
+++ b/build.sh
@@ -6,11 +6,12 @@ usage() {
   cat <<EOF
   usage: $0 [ OPTIONS ] [ -- Additional Docker Build Options ]
   Options
-  -h  --help      Show this message and exit
-  -n  --no-cache  Do not use the container runtime cache for images
-  -p  --platform  Platform to build (ex. linux/amd64; linux/arm64)
-  -t  --tag       Build with a specific docker tag
-  -x  --debug     Set the bash debug flag
+  -h  --help          Show this message and exit
+  -m  --github-mirror Github Mirror URL (defaults to using Github API directly)
+  -n  --no-cache      Do not use the container runtime cache for images
+  -p  --platform      Platform to build (ex. linux/amd64; linux/arm64)
+  -t  --tag           Build with a specific docker tag
+  -x  --debug         Set the bash debug flag
 
   Example:
 
@@ -26,6 +27,9 @@ while [ "$1" != "" ]; do
   case $1 in
     -h | --help )           usage
                             exit 1
+                            ;;
+    -m | --github-mirror )  shift
+                            GITHUB_MIRROR="$1"
                             ;;
     -n | --no-cache )       NOCACHE="--no-cache "
                             ;;
@@ -86,13 +90,18 @@ then
   fi
 fi
 
+GITHUB_MIRROR_ARG=""
+if [[ -n $GITHUB_MIRROR ]]
+then
+  GITHUB_MIRROR_ARG="--build-arg GITHUB_URL=$GITHUB_MIRROR"
+fi
 # for time tracking
 date
 date -u
 
 # we want the $@ args here to be re-split
-time ${CONTAINER_SUBSYS} $PLATFORM_BUILD_ARG $NOCACHE\
-  $CONTAINER_ARGS \
+time ${CONTAINER_SUBSYS} $PLATFORM_BUILD_ARG $NOCACHE \
+  $GITHUB_MIRROR_ARG $CONTAINER_ARGS \
   -t ocm-container:${BUILD_TAG} .
 
 # for time tracking

--- a/build.sh
+++ b/build.sh
@@ -97,13 +97,20 @@ if [[ -n $GITHUB_MIRROR ]]
 then
   GITHUB_MIRROR_ARG="--build-arg GITHUB_URL=$GITHUB_MIRROR"
 fi
+
+GITHUB_TOKEN_ARG=""
+if [[ -n $GITHUB_TOKEN ]]
+then
+  GITHUB_TOKEN_ARG="--build-arg GITHUB_TOKEN"
+fi
+
 # for time tracking
 date
 date -u
 
 # we want the $@ args here to be re-split
 time ${CONTAINER_SUBSYS} $PLATFORM_BUILD_ARG $NOCACHE \
-  $GITHUB_MIRROR_ARG $CONTAINER_ARGS \
+  $GITHUB_MIRROR_ARG $GITHUB_TOKEN_ARG $CONTAINER_ARGS \
   -t ocm-container:${BUILD_TAG} .
 
 # for time tracking

--- a/build.sh
+++ b/build.sh
@@ -78,6 +78,8 @@ source ${OCM_CONTAINER_CONFIG}
 ### start build
 echo "Using ${CONTAINER_SUBSYS} to build the container"
 
+${CONTAINER_SUBSYS} version
+
 PLATFORM_BUILD_ARG="build"
 ### Start multi-platform build handling
 if [[ -n $PLATFORM ]] 

--- a/utils/dockerfile_assets/gh_curl.sh
+++ b/utils/dockerfile_assets/gh_curl.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## GH Curl wraps CURL to a github API with an 
+## authorization header if the GITHUB_TOKEN env
+## var is present
+
+GITHUB_AUTH_HEADER=""
+
+if [[ -n $GITHUB_TOKEN ]]
+then
+  GITHUB_AUTH_HEADER="--header 'Authorization: Bearer $GITHUB_TOKEN'"
+fi
+
+curl $GITHUB_AUTH_HEADER $@


### PR DESCRIPTION
Still need to address the 403 errors from Github, but that's a whole pile of sticks to address so let's start with just getting Docker to actually pull the correct images and see if that might start working on the nightly builds/pr checks.

Removed the caching in PR checks. We might need to refactor this because if we attempt to run multiple PR checks in quick succession this will hit the GH rate limiting. However, if we hit the rate-limiting and the build fails, it will cache that 403 response in the image layer and fail the build later.