### PR TITLE
Update backplane tools to v1.1.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,7 +196,7 @@ RUN chmod +x /out/oc-nodepp
 
 FROM builder as backplane-tools-builder
 # Install via backplane-tools
-ARG BACKPLANE_TOOLS_VERSION="tags/v0.4.0"
+ARG BACKPLANE_TOOLS_VERSION="tags/v1.1.0"
 ENV BACKPLANE_TOOLS_URL_SLUG="openshift/backplane-tools"
 ENV BACKPLANE_TOOLS_URL="https://api.github.com/repos/${BACKPLANE_TOOLS_URL_SLUG}/releases/${BACKPLANE_TOOLS_VERSION}"
 RUN mkdir /backplane-tools


### PR DESCRIPTION
Update backplane tools to v1.1.0 release

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
