### PR TITLE
removes arm64 options from pr check and automated build

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -18,7 +18,7 @@ done
 set -u
 
 build_cmds=(
-  "bash build.sh -t latest-arm64 $NOCACHE -- '--platform=linux/arm64'"
+#  "bash build.sh -t latest-arm64 $NOCACHE -- '--platform=linux/arm64'"
   "bash build.sh -t latest-amd64 $NOCACHE -- '--platform=linux/amd64'"
 )
 

--- a/.ci/pull-request-check.sh
+++ b/.ci/pull-request-check.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 ./.ci/build.sh
 
 make TAG=latest-amd64 ARCHITECTURE=amd64 tag
-make TAG=latest-arm64 ARCHITECTURE=arm64 tag
+# make TAG=latest-arm64 ARCHITECTURE=arm64 tag

--- a/.ci/release-build.sh
+++ b/.ci/release-build.sh
@@ -6,10 +6,10 @@ set -euo pipefail
 ./.ci/build.sh
 
 make TAG=latest-amd64 ARCHITECTURE=amd64 tag
-make TAG=latest-arm64 ARCHITECTURE=arm64 tag
+# make TAG=latest-arm64 ARCHITECTURE=arm64 tag
 
 make TAG=latest-amd64 ARCHITECTURE=amd64 push
-make TAG=latest-arm64 ARCHITECTURE=arm64 push
+# make TAG=latest-arm64 ARCHITECTURE=arm64 push
 
 make build-manifest
 make push-manifest

--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,11 @@ build-manifest:
 	# builds the joint manifest for a new dual-arch container definition
 	# we're currently just going to use the build id from the AMD version of the image to tag here
 	$(eval AMD_BUILD_ID=$(shell ${CONTAINER_ENGINE} image inspect --format '{{slice .ID 7 19}}' $(IMAGE_NAME):latest-amd64))
-	$(eval ARM_BUILD_ID=$(shell ${CONTAINER_ENGINE} image inspect --format '{{slice .ID 7 19}}' $(IMAGE_NAME):latest-arm64))
+	# $(eval ARM_BUILD_ID=$(shell ${CONTAINER_ENGINE} image inspect --format '{{slice .ID 7 19}}' $(IMAGE_NAME):latest-arm64))
 	${CONTAINER_ENGINE} manifest exists $(IMAGE_URI):$(AMD_BUILD_ID)-$(GIT_REVISION) && ${CONTAINER_ENGINE} manifest rm $(IMAGE_URI):$(AMD_BUILD_ID)-$(GIT_REVISION) || true
-	${CONTAINER_ENGINE} manifest create $(IMAGE_URI):$(AMD_BUILD_ID)-$(GIT_REVISION) $(IMAGE_URI):$(ARM_BUILD_ID)-$(GIT_REVISION)-arm64 $(IMAGE_URI):$(AMD_BUILD_ID)-$(GIT_REVISION)-amd64
+	${CONTAINER_ENGINE} manifest create $(IMAGE_URI):$(AMD_BUILD_ID)-$(GIT_REVISION) $(IMAGE_URI):$(AMD_BUILD_ID)-$(GIT_REVISION)-amd64 # $(IMAGE_URI):$(ARM_BUILD_ID)-$(GIT_REVISION)-arm64
 	${CONTAINER_ENGINE} manifest exists $(IMAGE_URI):latest && ${CONTAINER_ENGINE} manifest rm $(IMAGE_URI):latest || true
-	${CONTAINER_ENGINE} manifest create $(IMAGE_URI):latest $(IMAGE_URI):$(ARM_BUILD_ID)-$(GIT_REVISION)-arm64 $(IMAGE_URI):$(AMD_BUILD_ID)-$(GIT_REVISION)-amd64
+	${CONTAINER_ENGINE} manifest create $(IMAGE_URI):latest $(IMAGE_URI):$(AMD_BUILD_ID)-$(GIT_REVISION)-amd64 # $(IMAGE_URI):$(ARM_BUILD_ID)-$(GIT_REVISION)-arm64
 
 .PHONY: push-manifest
 push-manifest:


### PR DESCRIPTION
Removes the arm64 multi-arch stuff for now until we can fix the rate limiting issue and have the worker nodes have the required packages to be able to build for multiple arch's