### PR TITLE
BACKPLANE_CONFIG_MOUNT as rw because cluster-console attempt to write a config there

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -246,7 +246,7 @@ then
 fi
 
 ## Set the mount path
-BACKPLANE_CONFIG_MOUNT="-v $BACKPLANE_CONFIG_DIR:/root/.config/backplane:ro"
+BACKPLANE_CONFIG_MOUNT="-v $BACKPLANE_CONFIG_DIR:/root/.config/backplane:rw"
 
 ## Create backplane config if missing
 if [ ! -f "$BACKPLANE_CONFIG_DIR/config.json" ]; then


### PR DESCRIPTION

Since we now use single backplane config for all envs, it should be ok to mount the bp conf location as rw, especially since cluster-console command attempts to write a temp nginx config there...