### PR TITLE
Removes publish All by default and locks to localhost for port binding

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -39,6 +39,10 @@ type cliFlag struct {
 	value          string
 	helpMsg        string
 	deprecationMsg string
+
+	// hidden, when set to true, will not show the flag
+	// as part of the `--help` output
+	hidden bool
 }
 
 func (f cliFlag) StringValue() string {
@@ -174,6 +178,13 @@ var standardFlags = []cliFlag{
 		flagType:  "string",
 		value:     "latest",
 		helpMsg:   "Sets the image tag to use",
+	},
+	{
+		name:     "publish-all-ports",
+		flagType: "bool",
+		value:    "false",
+		helpMsg:  "Publishes all defined ports to all interfaces. Equivelant of `--publish-all`",
+		hidden:   true,
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,6 +157,10 @@ func init() {
 				rootCmd.Flags().String(f.name, f.StringValue(), f.HelpString())
 			}
 		}
+
+		if f.hidden {
+			rootCmd.Flags().MarkHidden(f.name)
+		}
 	}
 
 	// Disable features list; see flags.go

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -191,6 +191,10 @@ func (e *Engine) execAndReplace(args ...string) error {
 
 // imageFQDN builds an image format string from container ref values
 func (c ContainerRef) imageFQDN() string {
+	if c.Image.Name == "" || c.Image.Tag == "" {
+		return ""
+	}
+
 	i := fmt.Sprintf("%s:%s", c.Image.Name, c.Image.Tag)
 
 	// The order of the repository and registry addition is important
@@ -264,7 +268,10 @@ func parseRefToArgs(c ContainerRef) ([]string, error) {
 
 	args = append(args, ttyToString(c.Tty, c.Interactive)...)
 
-	args = append(args, c.imageFQDN())
+	imageFQDN := c.imageFQDN()
+	if imageFQDN != "" {
+		args = append(args, imageFQDN)
+	}
 
 	// This needs to come last because command is a positional argument
 	if c.Command != "" {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -43,6 +43,7 @@ type ContainerRef struct {
 	BestEffortArgs  []string
 	Privileged      bool
 	RemoveAfterExit bool
+	LocalPorts      map[string]int
 }
 
 type VolumeMount struct {
@@ -233,8 +234,14 @@ func parseRefToArgs(c ContainerRef) ([]string, error) {
 		args = append(args, "--rm")
 	}
 
+	// If PublishAll is set - publish all of the ports. Otherwise, bind each
+	// one individually to localhost.
 	if c.PublishAll {
 		args = append(args, "--publish-all")
+	} else if c.LocalPorts != nil {
+		for service, _ := range c.LocalPorts {
+			args = append(args, fmt.Sprintf("--publish=127.0.0.1::%d", c.LocalPorts[service]))
+		}
 	}
 
 	if c.Envs != nil {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -52,3 +52,43 @@ func TestEnvsToString(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRefToArgs(t *testing.T) {
+	testCases := []struct {
+		name      string
+		container ContainerRef
+		expected  string
+	}{
+		{
+			name:      "Tests Publish All",
+			container: ContainerRef{PublishAll: true},
+			expected:  "--publish-all",
+		},
+	}
+
+	// run once for special empty arg string case
+	t.Run("Tests empty containerRef should return empty arg slice", func(t *testing.T) {
+		args, err := parseRefToArgs(ContainerRef{})
+		if err != nil {
+			t.Errorf("Unexpected Error: %v", err)
+		}
+		if len(args) > 0 {
+			t.Errorf("Expected empty arg slice, got len %d :: %v", len(args), args)
+		}
+	})
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := parseRefToArgs(tc.container)
+			if err != nil {
+				t.Errorf("Expected no error but got %v", err)
+			}
+			for _, arg := range args {
+				if arg == tc.expected {
+					return
+				}
+			}
+			t.Errorf("%s not found in args: %v", tc.expected, args)
+		})
+	}
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -57,12 +57,22 @@ func TestParseRefToArgs(t *testing.T) {
 	testCases := []struct {
 		name      string
 		container ContainerRef
-		expected  string
+		expected  []string
 	}{
 		{
 			name:      "Tests Publish All",
 			container: ContainerRef{PublishAll: true},
-			expected:  "--publish-all",
+			expected:  []string{"--publish-all"},
+		},
+		{
+			name:      "Tests LocalPorts single",
+			container: ContainerRef{LocalPorts: map[string]int{"console": 9999}},
+			expected:  []string{"--publish=127.0.0.1::9999"},
+		},
+		{
+			name:      "Tests LocalPorts multiple",
+			container: ContainerRef{LocalPorts: map[string]int{"console": 9999, "promlens": 8080}},
+			expected:  []string{"--publish=127.0.0.1::9999", "--publish=127.0.0.1::8080"},
 		},
 	}
 
@@ -77,18 +87,47 @@ func TestParseRefToArgs(t *testing.T) {
 		}
 	})
 
+	// run once for special empty local port map case
+	t.Run("Tests empty LocalPorts map returns no args", func(t *testing.T) {
+		args, err := parseRefToArgs(ContainerRef{LocalPorts: map[string]int{}})
+		if err != nil {
+			t.Errorf("Unexpected Error: %v", err)
+		}
+		if len(args) > 0 {
+			t.Errorf("Expected empty arg slice, got len %d :: %v", len(args), args)
+		}
+	})
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			args, err := parseRefToArgs(tc.container)
 			if err != nil {
 				t.Errorf("Expected no error but got %v", err)
 			}
+
+			// create the map to determine if all have been found
+			expectedFound := map[string]bool{}
+			for _, flag := range tc.expected {
+				expectedFound[flag] = false
+			}
+
+			// loop through all args and mark as found
 			for _, arg := range args {
-				if arg == tc.expected {
+				for _, expected := range tc.expected {
+					if arg == expected {
+						expectedFound[expected] = true
+					}
+				}
+			}
+
+			// loop through all of the expected to be found args and if
+			// not all are true then return an error
+			for _, found := range expectedFound {
+				if !found {
+					t.Errorf("%s not found in args: %v", tc.expected, args)
 					return
 				}
 			}
-			t.Errorf("%s not found in args: %v", tc.expected, args)
 		})
 	}
 }

--- a/pkg/ocmcontainer/ocmcontainer.go
+++ b/pkg/ocmcontainer/ocmcontainer.go
@@ -151,7 +151,10 @@ func New(cmd *cobra.Command, args []string) (*ocmContainer, error) {
 	// disable-console-port is deprecated so this we're also checking the new --no-console-port flag
 	// This can be simplified when disable-console-port is deprecated and removed
 	if featureEnabled("console-port") && !viper.GetBool("disable-console-port") {
-		c.PublishAll = true
+		if c.LocalPorts == nil {
+			c.LocalPorts = map[string]int{}
+		}
+		c.LocalPorts["console"] = 9999
 	}
 
 	// GCloud configuration
@@ -262,7 +265,8 @@ func New(cmd *cobra.Command, args []string) (*ocmContainer, error) {
 }
 
 func (o *ocmContainer) consolePortEnabled() bool {
-	return o.container.Ref.PublishAll
+	_, ok := o.container.Ref.LocalPorts["console"]
+	return ok
 }
 
 func (o *ocmContainer) newConsolePortMap() error {

--- a/pkg/ocmcontainer/ocmcontainer.go
+++ b/pkg/ocmcontainer/ocmcontainer.go
@@ -33,6 +33,9 @@ type Error string
 func (e Error) Error() string { return string(e) }
 
 const (
+	defaultConsolePort = 9999
+
+	// TODO: make this template accept a param for the console port
 	consolePortLookupTemplate     = `{{(index (index .NetworkSettings.Ports "9999/tcp") 0).HostPort}}`
 	containerStateRunningTemplate = `{{.State.Running}}`
 
@@ -154,7 +157,7 @@ func New(cmd *cobra.Command, args []string) (*ocmContainer, error) {
 		if c.LocalPorts == nil {
 			c.LocalPorts = map[string]int{}
 		}
-		c.LocalPorts["console"] = 9999
+		c.LocalPorts["console"] = defaultConsolePort
 	}
 
 	// GCloud configuration

--- a/pkg/ocmcontainer/ocmcontainer.go
+++ b/pkg/ocmcontainer/ocmcontainer.go
@@ -429,6 +429,11 @@ func parseFlags(c engine.ContainerRef) (engine.ContainerRef, error) {
 		)
 	}
 
+	if viper.GetBool("publish-all-ports") {
+		log.Warn("Publishing all ports can result in any machine with network access to your computer to have the ability to view potentially sensitive customer data. This is not recommended, especially if you're not sure what else is on the network you're working from. Use this option only with extreme caution.")
+		c.PublishAll = true
+	}
+
 	return c, nil
 }
 


### PR DESCRIPTION
During some testing we realized that by using the `--publish-all` functionality we inadvertently open up the exposed port to all other hosts on our local networks, posing a potential security risk.

This changes that functionality so that by default it binds the console port to the local interface, so that you can only access the service running in ocm-container from your local machine and not other hosts on the network.

Effectively changes:
```
FROM:
42ba10b210d4  quay.io/app-sre/ocm-container:latest                        22 hours ago   Up 22 hours   0.0.0.0:43407->9999/tcp    dreamy_blackwell

TO:
5660b923b832  quay.io/app-sre/ocm-container:latest                        9 seconds ago  Up 9 seconds  127.0.0.1:35023->9999/tcp  intelligent_hoover
```

I ssh'd into another machine and curl'd my macbook and it served the contents running on port 43407 to my other machine. After changing the binding to the bottom example, my macbook replied with `curl: (7) Failed to connect to 192.168.1.212 port 35023: Connection refused`

---

As an architecture decision, I figured that it would be better to add a LocalPorts map to the ContainerRef so that we could optionally further expand the availability of ports in the future. For example, in some recent testing it would have been nice to have the ability to have a console running as well as the ability to port forward for PromLens; though that can come in a future PR.