### PR TITLE
create config folder before creating config file within it

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -210,6 +211,12 @@ var initCmd = &cobra.Command{
 			// TODO: FIGURE THIS OUT
 			getValue("all", viper.GetViper(), showSensitiveValues) // THIS IS RETURNING TOO MANY
 			return nil
+		}
+
+		directory := filepath.Dir(cfgFile)
+		err = os.MkdirAll(directory, 0o750)
+		if err != nil {
+			return fmt.Errorf("creating config file folder %s: %w", directory, err)
 		}
 
 		err = viper.WriteConfig()
@@ -575,10 +582,8 @@ func buildNewConfig(legacyData map[string]any, existingConfig, showSensitiveValu
 
 		configMap := createConfigurationMap(legacyData, migrate)
 		return configMap, nil
-	}
-
-	// If assumeYes is not true, prompt the user to write a new config
-	if !assumeYes {
+	} else {
+		// If assumeYes is not true, prompt the user to write a new config
 		writeConfig, err = promptUserToWriteConfig(existingConfig)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Hey :)

`ocm-container configure init` fails to save the config file when the folder `~/.config/ocm-container` doesn't exist.
This PR fixes it by adding the equivalent of `mkdir -p "$(dirname "$cfgFile")"` before the call to `viper.WriteConfig()`

![image](https://github.com/openshift/ocm-container/assets/5539202/a664a0bc-1708-4d58-92f6-53f3202b2a51)

Edit: sorry for reformatting the unrelated else-statement. I couldn't resist! :sweat_smile: 