### PR TITLE
Add version subcommand

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,8 @@ builds:
     goarch:
       - amd64
       - arm64
-
+    ldflags:
+      - -X github.com/openshift/ocm-container/pkg/utils.Version={{.Version}}
 archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/viper"
 	easy "github.com/t-tomalak/logrus-easy-formatter"
 
+	"github.com/openshift/ocm-container/cmd/version"
 	"github.com/openshift/ocm-container/pkg/ocmcontainer"
 	"github.com/openshift/ocm-container/pkg/subprocess"
 )
@@ -168,6 +169,8 @@ func init() {
 		rootCmd.Flags().Bool(flag.name, false, strings.ToLower(flag.helpMsg+flag.deprecationMsg))
 	}
 
+	// Register sub-commands
+	rootCmd.AddCommand(version.VersionCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,50 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime/debug"
+	"strings"
+
+	"github.com/openshift/ocm-container/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type versionResponse struct {
+	Commit  string `json:"commit"`
+	Version string `json:"version"`
+	Latest  string `json:"latest"`
+}
+
+// VersionCmd represents the version command
+var VersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Prints the version",
+	Long:  `Display the version of ocm-container version`,
+	RunE:  version,
+}
+
+func version(cmd *cobra.Command, args []string) error {
+	gitCommit := "unknown"
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				gitCommit = setting.Value
+				break
+			}
+		}
+	}
+
+	latest, _ := utils.GetLatestVersion() // let's ignore this error, just in case we have no internet access
+	ver, err := json.MarshalIndent(&versionResponse{
+		Commit:  gitCommit,
+		Version: utils.Version,
+		Latest:  strings.TrimPrefix(latest, "v"),
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(ver))
+	return nil
+}

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	VersionAPIEndpoint     = "https://api.github.com/repos/openshift/ocm-container/releases/latest"
+	VersionAddressTemplate = "https://github.com/openshift/ocm-container/releases/download/v%s/ocm-container_%s_%s_%s.tar.gz" // version, version, GOOS, GOARCH
+)
+
+var (
+	// GitCommit is the short git commit hash from the environment
+	// Will be set during build process via GoReleaser
+	// See also: https://pkg.go.dev/cmd/link
+	GitCommit string
+
+	// Version is the tag version from the environment
+	// Will be set during build process via GoReleaser
+	// See also: https://pkg.go.dev/cmd/link
+	Version string
+)
+
+type gitHubResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+// getLatestVersion connects to the GitHub API and returns the latest ocm-container tag name
+func GetLatestVersion() (latest string, err error) {
+	client := http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, VersionAPIEndpoint, nil)
+	if err != nil {
+		return latest, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return latest, err
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return latest, err
+	}
+
+	githubResp := gitHubResponse{}
+	err = json.Unmarshal(body, &githubResp)
+	if err != nil {
+		return latest, err
+	}
+
+	return githubResp.TagName, nil
+}


### PR DESCRIPTION
## What 
Display the current ocm-container version and latest version
```
{
  "commit": "65ef57625bf38a6dbc4d4e18e03fa3ee5298abac",
  "version": "0.1.0",
  "latest": "0.2.0"
}
```
