### PR TITLE
Replaces UBI with Stream9-minimal image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:9.3-1612
+ARG BASE_IMAGE=quay.io/centos/centos:stream9-minimal
 FROM ${BASE_IMAGE} as tools-base
 ARG OUTPUT_DIR="/opt"
 


### PR DESCRIPTION
UBI is not a redistributable image, and should only be used on RHEL machines. Therefore, we should use the CentOS Stream image.

However, the [centos quay repo](https://quay.io/repository/centos/centos?tab=tags) does not tag their images with anything more granular than `stream9-minimal`. This image does look to be updated regularly, though, which may or may not be an issue.

I've built and used this image locally for a few days now without issue on my M1 MBP. 

I've opened this PR for further discussion, and do not have an opinion one way or the other on whether this gets merged or not.

Migrating to stream9-minmal puts us under the "letter of the rule", however since this is an internal tool really used only by RH SREs on CSBs - we are still following the "_spirit of the rule_".