### PR TITLE
Remove the gcloud-sdk repo

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -216,11 +216,6 @@ FROM ocm-container-minimal as dnf-install
 # Add Platform Conversion Tool for arm64/x86_64 compatibility
 COPY utils/dockerfile_assets/platforms.sh /usr/local/bin/platform_convert
 
-# Add google-cloud-sdk repo
-COPY utils/dockerfile_assets/google-cloud-sdk.repo /etc/yum.repos.d/
-# Use  Platform Conversion Tool to set google-cloud-sdk repo arch
-RUN platform_convert -i /etc/yum.repos.d/google-cloud-sdk.repo --x86_64 --aarch64
-
 # Add epel repos
 RUN rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9 \
       && rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm


### PR DESCRIPTION
This seems to be unused at the moment and we aren't installing gcloud.
Gcloud is installed with backplane-tools now so we can grab it from there.
A future MR will do that part.