### PR TITLE
Update goreleaser/template to v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 project_name: 'ocm-container'
 before:


### PR DESCRIPTION
Update to use Goreleaser version 2.  I've tested this locally and has been working.  This will require TLs to update their Goreleaser version in use to v2.  Goreleaser will refuse to run v2 templates with v1, so it will be clear to them if they haven't yet updated.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
