### PR TITLE
Adds fallback to offline access token login

### DIFF
--- a/utils/bashrc.d/00-ocm.bashrc
+++ b/utils/bashrc.d/00-ocm.bashrc
@@ -7,7 +7,22 @@ fi
 
 if ! ocm whoami &> /dev/null
 then
-  ocm login --url=$OCM_URL --use-device-code
+  if [[ -n $OFFLINE_ACCESS_TOKEN ]] && grep -e "stage" -e "integration" <<< $OCM_URL &> /dev/null
+  then
+    ## Warn users trying to use offline access tokens in stage/int who have not passed through config
+    echo "ERROR: Offline Access tokens will no longer work on staging or integration."
+    echo "INFO: falling back to logging in with device code"
+    echo "INFO: To prevent this from happening every time you create a container - log into OCM outside of the"
+    echo "      container and ocm-container will pass the ocm config file through to the container"
+    ocm login --url=$OCM_URL --use-device-code
+
+  elif [[ -n $OFFLINE_ACCESS_TOKEN ]]
+  then
+    ## Warn users trying to use offline access tokens in prod, but allow it to continue working for now
+    echo "WARN: Offline Access Tokens are being deprecated"
+    echo "      Consider logging into ocm outside of the container with short lived access tokens"
+    ocm login --url=$OCM_URL --token $OFFLINE_ACCESS_TOKEN
+  fi
 fi
 
 # Wrap the ocm backplane console command to handle automation for


### PR DESCRIPTION
Adds a fallback for prod access with offline access tokens but adds a warning, and proceeds to use device code login for OCM when in the staging or integration environments.

Per some feedback received in slack this should allow both access mechanisms to give SREs more time to switch without breaking current prod workflows.