### PR TITLE
Adds ability to use GITHUB_TOKEN auth for backplane-tools

### DIFF
--- a/.ci/pull-request-check.sh
+++ b/.ci/pull-request-check.sh
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+
 # Build the images
-make BUILD_ARGS="--no-cache" build-image-amd64
+make BUILD_ARGS="--no-cache --build-arg GITHUB_TOKEN=${GITHUB_TOKEN}" build-image-amd64
 # make BUILD_ARGS="--no-cache" build-image-arm64
 
 make TAG=latest-amd64 ARCHITECTURE=amd64 tag

--- a/.ci/release-build.sh
+++ b/.ci/release-build.sh
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+
 # Build the images
-make BUILD_ARGS="--no-cache" build-image-amd64
+make BUILD_ARGS="--no-cache --build-arg GITHUB_TOKEN=${GITHUB_TOKEN}" build-image-amd64
 # make BUILD_ARGS="--no-cache" build-image-arm64
 
 make TAG=latest-amd64 ARCHITECTURE=amd64 tag

--- a/Containerfile
+++ b/Containerfile
@@ -13,7 +13,7 @@ FROM tools-base as backplane-tools
 ARG OUTPUT_DIR="/opt"
 
 # Set GH_TOKEN to use authenticated GH requests
-ARG GH_TOKEN
+ARG GITHUB_TOKEN
 
 ARG BACKPLANE_TOOLS_VERSION="tags/v1.2.0"
 ENV BACKPLANE_TOOLS_URL_SLUG="openshift/backplane-tools"


### PR DESCRIPTION
Adds the ability to use an exported `GITHUB_TOKEN` env variable for
backplane-tools authenticated installs.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
