### PR TITLE
Add 'name' parameter for OCM cluster search

### DIFF
--- a/utils/bashrc.d/06-sre-login-libs.bashrc
+++ b/utils/bashrc.d/06-sre-login-libs.bashrc
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 
 function cluster_info_env_export(){
-  SEARCH_STRING="id like '$INITIAL_CLUSTER_LOGIN' or external_id like '$INITIAL_CLUSTER_LOGIN' or display_name like '$INITIAL_CLUSTER_LOGIN'"
+  SEARCH_STRING="id like '$INITIAL_CLUSTER_LOGIN' or external_id like '$INITIAL_CLUSTER_LOGIN' or name like '$INITIAL_CLUSTER_LOGIN' or display_name like '$INITIAL_CLUSTER_LOGIN'"
   cluster_details=$(ocm list clusters --parameter=search="(($SEARCH_STRING))" --columns "id, external_id, name" --no-headers)
   CLUSTER_ID=$(awk '{print $1}' <<< $cluster_details)
   CLUSTER_UUID=$(awk '{print $2}' <<< $cluster_details)


### PR DESCRIPTION
Some clusters use "display_name" as a longer, more descriptive field.
And example of this is `osd-v4stg-aws`, which has:

```
Display Name:	SRE long lived cluster in production: osd-v4stg-aws
```

This causes osd-v4stg-aws (or others) to not be found when searching by the human
friendly name, as identified by @rendhalver in a [recent pr
review](https://github.com/openshift/ocm-container/pull/300#issuecomment-2287870189).

This PR adds "name" to the OCM cluster search parameters, which is the
parameter used by ocm-cli when it performs the same search.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
