### PR TITLE
BUGFIX: Make OCM environment inside of container ephemeral

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -193,6 +193,9 @@ ENV OCM_BACKPLANE_CONSOLE_PORT 9999
 EXPOSE $OCM_BACKPLANE_CONSOLE_PORT
 ENTRYPOINT ["/bin/bash"]
 
+# Create a directory for the ocm config file
+RUN mkdir -p /root/.config/ocm
+
 ### Final Minimal Image
 FROM base-update as ocm-container-minimal
 # ARG keeps the values from the final image

--- a/README.md
+++ b/README.md
@@ -18,14 +18,11 @@ Thank you for your patience as we make this transition.
 
 First, download the latest release for your OS/Architecture: [https://github.com/openshift/ocm-container/releases](https://github.com/openshift/ocm-container/releases)
 
-Setup the base configuration, setting your preferred container engine (Podman or Docker) and OCM Token:
+Setup the base configuration, setting your preferred container engine (Podman or Docker):
 
 ```
 ocm-container configure set engine CONTAINER_ENGINE
-ocm-container configure set offline_access_token OCM_OFFLINE_ACCESS_TOKEN
 ```
-
-__Note:__ the OCM offline_access_token will be deprecated in the near future. OCM Container will be updated to handle this and assist in migrating your configuration.
 
 This is all that is required to get started with the basic setup, use the OCM cli, and log into clusters with OCM Backplane.
 
@@ -54,11 +51,35 @@ Running ocm-container can be done by executing the binary alone with no flags.
 ocm-container
 ```
 
+### Authentication
+
+OCM authentication defaults to using your OCM Config, first looking for the `OCM_CONFIG` environment variable.
+
+```
+OCM_CONFIG="~/.config/ocm/ocm.json.prod" ocm-container
+```
+
+If no `OCM_CONFIG` is specified, ocm-container will login to the environment proved in the `OCMC_OCM_URL` environment variable (prod, stage, int, prodgov) if set, then values provided by the `--ocm-url` flag.  If nothing is specified, the `--ocm-url` flag is set to "production" and that environment is used.
+
+```
+OCMC_OCM_URL=staging ocm-container
+
+# or
+
+ocm-container --ocm-url=staging
+```
+
+Upon login, OCM Container will copy a new ocm.json file to your `~/.config/ocm/` directory, in the format `ocm.json.ocm-container.$ocm_env`.  This file can be reused with the `OCM_CONFIG` environment variable in the future, if desired.
+
 Passing a cluster ID to the command with `--cluster-id` or `-C` will log you into that cluster after the container starts. This can be the cluster's OCM UUID, the OCM internal ID or the cluster's display name.
+
+### Cluster Login
 
 ```
 ocm-container --cluster-id CLUSTER_ID
 ```
+
+### Entrypoint
 
 By default, the container's Entrypoint is `/bin/bash`. You may also use the `--entrypoint=<command>` flag to change the container's Entrypoint as you would with a container engine.  The ocm-container binary also treats trailing non-flag arguments as container CMD arguments, again similar to how a container engine does.  For example, to execute the `ls` command as the Entrypoint and the flags `-lah` as the CMD, you can run:
 
@@ -73,6 +94,8 @@ You may also change the Entrypoint and CMD for use with an initial cluster ID fo
 ```
 ocm-container --entrypoint=ls --cluster-id CLUSTER_ID -- -lah
 ```
+
+### Container engine options
 
 Additional container engine arguments can be passed to the container using the `--launch-ops` flag.  These will be passed as-is to the engine, and are a best-effort support.  Some flags may conflict with ocm-container function.
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -93,6 +93,7 @@ func (e *Engine) Attach(c *Container) error {
 func (e *Engine) Copy(cpArgs ...string) (string, error) {
 	var args = []string{"cp"}
 	args = append(args, cpArgs...)
+	log.Debugf("executing command to copy files: %v %v\n", e.binary, args)
 	return e.exec(args...)
 }
 
@@ -138,7 +139,7 @@ func (e *Engine) Exec(c *Container, execArgs []string) (string, error) {
 	args = append(args, execArgs...)
 
 	if !e.dryRun {
-		log.Debug(fmt.Sprintf("executing command inside the running container: %v %v\n", e.binary, append([]string{e.engine}, args...)))
+		log.Debugf("executing command inside the running container: %v %v\n", e.binary, args)
 	}
 
 	out, err := e.exec(args...)
@@ -165,7 +166,7 @@ func (e *Engine) Start(c *Container, attach bool) error {
 	out, err := e.exec("start", c.ID)
 
 	// This is not log output; do not pass through a logger
-	log.Debug(fmt.Sprint("Exec output: " + out))
+	log.Debug("Exec output: " + out)
 
 	return err
 }

--- a/utils/bashrc.d/14-kube-ps1.bashrc
+++ b/utils/bashrc.d/14-kube-ps1.bashrc
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-export PS1="[\W {\[\033[1;32m\]\${OCM_URL}\[\033[0m\]} \$(kube_ps1)]\$ "
+export PS1="[\W {\[\033[1;32m\]\$(ocm config get url)\[\033[0m\]} \$(kube_ps1)]\$ "
 export KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 export KUBE_PS1_SYMBOL_ENABLE=false


### PR DESCRIPTION
This fixes a bug in ocm-container where the ocm environment was being
read differently by the ocm cli and rosa cli due to the way
ocm-container used the OCM_URL environment variable.

This PR will now set the environment inside the container to be, in this
order:

* set by the OCM_CONFIG environment variable (eg:
  `OCM_CONFIG=~/.config/ocm/ocm.json.stage ocm-container`)
* `OCMC_OCM_URL` environment varible
* the `--ocm-url` flaga (`ocm-container --ocm-url poduction`)
* default: prod

Upon running ocm-container, ocm-contianer will determine if the user is
logged in, using the external OCM config file provide, and then
authenticate if needed. It will then copy the OCM config to a file
alongside any existing OCM config in the format
`ocm.json.ocm-container.$ocm_env`.  This file can be reused with
ocm-container as the OCM_CONFIG env (or not), if desired.  The contents
of the new config file are copied into the contianer before it is
launched, ensuring that the container is ephemeral, and no changes
outside or inside the container change each other.

This setup has been tested to confirm ROSA is using the correct OCM URL.

You will need to build and use a new OCM Container image that include
the Containerfile changes in this PR in order to test it properly, and
when merged, users will need to use the newly built image with the new
binary.

A new 4.0.1 release should be cut with the contents of this when
approved, and version 4.0.0 deleted/removed.

Fixes [OSD-25064](https://issues.redhat.com//browse/OSD-25064)

Signed-off-by: Chris Collins <collins.christopher@gmail.com>