### PR TITLE
 Suppress unnecessary output at normal log levels

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -183,7 +183,7 @@ var standardFlags = []cliFlag{
 		name:     "publish-all-ports",
 		flagType: "bool",
 		value:    "false",
-		helpMsg:  "Publishes all defined ports to all interfaces. Equivelant of `--publish-all`",
+		helpMsg:  "Publishes all defined ports to all interfaces. Equivalent of `--publish-all`",
 		hidden:   true,
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -193,9 +193,8 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintf(os.Stderr, "Using config file: %s\n", viper.ConfigFileUsed())
-	} else {
+	err := viper.ReadInConfig()
+	if err != nil {
 		// TODO: Prompt to run the config command
 		fmt.Fprintf(os.Stderr, "Error reading config file: %s\n", err)
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -100,7 +100,19 @@ func (e *Engine) Copy(cpArgs ...string) (string, error) {
 // Exec creates a container with the given args, returning a *Container object
 func (e *Engine) Create(c ContainerRef) (*Container, error) {
 	var err error
-	var args = []string{"create", pullPolicyString(e.pullPolicy)}
+	var args = []string{"create", pullPolicyToString(e.pullPolicy)}
+
+	// --quiet suppresses image pull policy output which is written to /dev/null and
+	// misinterpreted by os.Exec as an error message
+	switch log.GetLevel() {
+	case log.TraceLevel:
+		// pass
+	case log.DebugLevel:
+		// pass
+	default:
+		args = append(args, "--quiet")
+	}
+
 	err = validateContainerRef(c)
 	if err != nil {
 		return nil, err
@@ -314,8 +326,7 @@ func envsToString(envs map[string]string) []string {
 	return args
 }
 
-// --quiet suppresses image pull output which is written to /dev/null and
-// misinterpreted by os.Exec as an error message
-func pullPolicyString(s string) string {
+// pullPolicyToString returns a string for the --pull flag as a valid container engine argument
+func pullPolicyToString(s string) string {
 	return fmt.Sprintf("--pull=%s", s)
 }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -199,3 +199,26 @@ func TestParseRefToArgs(t *testing.T) {
 		}
 	})
 }
+
+func TestPullPolicyToString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Always", "always", "--pull=always"},
+		{"Missing", "missing", "--pull=missing"},
+		{"Never", "never", "--pull=never"},
+		{"Newer", "newer", "--pull=newer"},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := pullPolicyToString(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected '%s', but got '%s'", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 Suppress unnecessary output at normal log levels

As an SRE I would like non-debug output suppressed when running
OCM Contianer.

Currently, it prints the container engine image pull
output to the screen. This is messy and not compliant with the "no news
is good news" Unix/Linux terminal/cli philosophy.

This PR has a case switch for log levels > debug, appending
the `--quiet` flag to the Podman/Docker create command, which will
suppress the output for any higher log levels.

OCM Container also prints the config file used for Viper argument
parsing.

This PR also removes that config file parsing ouput, unless there is an
error, since location is standardized and documented.

Secondary commit unrelated to this main PR includes a minor spelling fix to the CLI flags help message.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>