### PR TITLE
Update docs for running built images

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,13 @@ Then you should just be able to build the container as usual
 podman build -t ocm-container:latest .
 ```
 
+### Note
+
+When running local images you may need to set `pull` to `missing`
+`ocm-container -I $IMAGE -t $TAG --pull missing`
+If you are always running local or images with a set tag, you can set this in your config like this:
+`ocm-container configure set pull missing`
+
 Note: the `ROSA` cli is not present on the arm64 version as there is no [pre-built arm64 binary](https://github.com/openshift/rosa/issues/874) that can be gathered, and we've decided that we don't use that cli enough to bother installing it from source within the build step.
 
 ## Development


### PR DESCRIPTION
When running locally built images ocm-container will still try to pull the image.
Add notes to the docs to help get that working.