### PR TITLE
Fix the osdctl cluster context failure on the latest osdctl version

### DIFF
--- a/utils/bashrc.d/99-osdctl-cluster-context.bashrc
+++ b/utils/bashrc.d/99-osdctl-cluster-context.bashrc
@@ -10,5 +10,5 @@ fi
 
 if [ -n "$CLUSTER_ID" ] && [ -z "$SKIP_CLUSTER_CONTEXT" ]; then
 	echo "Checking the context on $CLUSTER_ID"
-	osdctl cluster context "$CLUSTER_ID"
+	osdctl cluster context --cluster-id "$CLUSTER_ID"
 fi


### PR DESCRIPTION
The --cluster-id option is mandatory since osdctl version 0.43.0.
This will cause the ocm-container show cluster context failed at the login.
This PR added the  --cluster-id in the script to make sure the cluster context info could be displayed.

Change has been tested locally.