### PR TITLE
Update CI scripts to show if GITHUB_TOKEN is set

### DIFF
--- a/.ci/pull-request-check.sh
+++ b/.ci/pull-request-check.sh
@@ -4,9 +4,17 @@ set -euo pipefail
 
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 
+if [[ -z ${GITHUB_TOKEN} ]]
+then
+  echo "No GITHUB_TOKEN set; downloads may be rate-limited"
+else
+  echo "GITHUB_TOKEN set"
+fi
+
 # Build the images
 make BUILD_ARGS="--no-cache --build-arg GITHUB_TOKEN=${GITHUB_TOKEN}" build-image-amd64
-# make BUILD_ARGS="--no-cache" build-image-arm64
-
 make TAG=latest-amd64 ARCHITECTURE=amd64 tag
+
+# ARM builds not currently supported in CI
+# make BUILD_ARGS="--no-cache --build-arg GITHUB_TOKEN=${GITHUB_TOKEN}"  build-image-arm64
 # make TAG=latest-arm64 ARCHITECTURE=arm64 tag

--- a/.ci/release-build.sh
+++ b/.ci/release-build.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 
+if [[ -z ${GITHUB_TOKEN} ]]
+then
+  echo "No GITHUB_TOKEN set; downloads may be rate-limited"
+else
+  echo "GITHUB_TOKEN set"
+fi
+
 # Build the images
 make BUILD_ARGS="--no-cache --build-arg GITHUB_TOKEN=${GITHUB_TOKEN}" build-image-amd64
 # make BUILD_ARGS="--no-cache" build-image-arm64


### PR DESCRIPTION
Updates the CI scripts to emit a warning message if the GITHUB_TOKEN is not set, for visibility.
    
Signed-off-by: Chris Collins <collins.christopher@gmail.com>
