### PR TITLE
[propose] osdctl needs vault token for accessing dt logs

### DIFF
--- a/pkg/featureSet/osdctl/osdctl.go
+++ b/pkg/featureSet/osdctl/osdctl.go
@@ -4,6 +4,7 @@ import "github.com/openshift/ocm-container/pkg/engine"
 
 const (
 	osdctlConfigDir = ".config/osdctl"
+	vaultTokenFile  = ".vault-token"
 )
 
 type Config struct {
@@ -14,11 +15,18 @@ func New(home string) (*Config, error) {
 
 	config := &Config{}
 
-	config.Mounts = append(config.Mounts, engine.VolumeMount{
-		Source:       home + "/" + osdctlConfigDir,
-		Destination:  "/root/" + osdctlConfigDir,
-		MountOptions: "ro",
-	})
-
+	config.Mounts = append(
+		config.Mounts,
+		engine.VolumeMount{
+			Source:       home + "/" + osdctlConfigDir,
+			Destination:  "/root/" + osdctlConfigDir,
+			MountOptions: "ro",
+		},
+		engine.VolumeMount{
+			Source:       home + "/" + vaultTokenFile,
+			Destination:  "/root/" + vaultTokenFile,
+			MountOptions: "rw",
+		},
+	)
 	return config, nil
 }


### PR DESCRIPTION
osdctl needs vault token for accessing dt logs, those who enable osdctl now also will mount ~/.vault-token when missing an error is thrown:
```
Error: error: problem reading source volume: /home/tomas/.vault-token: stat /home/tomas/.vault-token: no such file or directory        
```
which is rectified by `touch` vault auth