### PR TITLE
Install bind-utils in micro

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -97,7 +97,10 @@ ARG OUTPUT_DIR="/opt"
 ARG BIN_DIR="/usr/local/bin"
 
 # Install the dig binary for resolving backplane hostname
-RUN microdnf --assumeyes --nodocs install bind-utils
+RUN microdnf --assumeyes --nodocs install \
+      bind-utils \
+      && microdnf clean all \
+      && rm -rf /var/cache/yum
 
 COPY --from=backplane-tools /${OUTPUT_DIR}/ocm           ${BIN_DIR}
 RUN ocm completion > /etc/bash_completion.d/ocm


### PR DESCRIPTION
This PR installs the `bind-utils` in the micro image.

The use case is that we are going to use the `ocm-container-micro` image to run the `backplane-verify` job, in the job we will need to get the IP of a given service, which we will need the `dig` command.  The `ocm-container-minimal` has more packages than we need, thus having it in mirco should be more suitable.

