### PR TITLE
Fix accidental skip of registry login

### DIFF
--- a/.ci/release-build.sh
+++ b/.ci/release-build.sh
@@ -37,7 +37,7 @@ echo "Building full image for architecture: ${ARCH}"
 make CACHE="" build-full
 make ARCHITECTURE=${ARCH} tag-full
 
-#make registry-login
+make registry-login
 
 # Push the images
 for ARCH in amd64; do


### PR DESCRIPTION
    Fix accidental skip of registry login
    
    The last PR was accidentally committed with the `make registry-login` step in the `.ci/release-build.sh` commented out.  This PR fixes that issue.
    
    Signed-off-by: Chris Collins <collins.christopher@gmail.com>
