### PR TITLE
remove image override for cluster console

### DIFF
--- a/utils/bin/cluster-console
+++ b/utils/bin/cluster-console
@@ -19,6 +19,5 @@ then
   exit 1
 fi
 
-# taislam_osd image is used as a temporary workaround until OCPBUGS-14550 is fixed 
-exec ocm backplane console --port $OCM_BACKPLANE_CONSOLE_PORT  --image=quay.io/taislam_osd/openshift-console \
+exec ocm backplane console --port $OCM_BACKPLANE_CONSOLE_PORT \
   | sed "s/${OCM_BACKPLANE_CONSOLE_PORT}/$(cat /tmp/portmap)/"


### PR DESCRIPTION
Removes the image override for the cluster console so we're using the correct image.