### PR TITLE
fix persistent histories

### DIFF
--- a/pkg/featureSet/persistentHistories/persistentHistories.go
+++ b/pkg/featureSet/persistentHistories/persistentHistories.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/openshift/ocm-container/pkg/deprecation"
 	"github.com/openshift/ocm-container/pkg/engine"
 	"github.com/openshift/ocm-container/pkg/ocm"
 )
@@ -24,6 +23,7 @@ func New(home, cluster string) (*Config, error) {
 	var err error
 
 	config := &Config{}
+	config.Env = make(map[string]string)
 
 	ocmClient, err := ocm.NewClient()
 	if err != nil {
@@ -51,15 +51,4 @@ func New(home, cluster string) (*Config, error) {
 	config.Env["HISTFILE"] = histFile
 
 	return config, nil
-}
-
-func DeprecatedConfig() bool {
-	env := os.Getenv("PERSISTENT_CLUSTER_HISTORIES")
-	if env != "" {
-		deprecation.Print(
-			"PERSISTENT_CLUSTER_HISTORIES",
-			"Persistent histories will be enabled by default; use --no-persistent-histories to disable")
-		return true
-	}
-	return false
 }

--- a/pkg/featureSet/persistentHistories/persistentHistories.go
+++ b/pkg/featureSet/persistentHistories/persistentHistories.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	histFile     = "/root/per-cluster/.bash_history"
-	destDir      = "/root/per-cluster"
+	histFile     = ".bash_history"
+	destDir      = "/root/.per-cluster"
 	sourceSubDir = "/.config/ocm-container/per-cluster-persistent/"
 )
 
@@ -48,7 +48,7 @@ func New(home, cluster string) (*Config, error) {
 		MountOptions: "rw",
 	})
 
-	config.Env["HISTFILE"] = histFile
+	config.Env["HISTFILE"] = destDir + "/" + histFile
 
 	return config, nil
 }

--- a/pkg/ocmcontainer/ocmcontainer.go
+++ b/pkg/ocmcontainer/ocmcontainer.go
@@ -217,15 +217,13 @@ func New(cmd *cobra.Command, args []string) (*ocmContainer, error) {
 	// before entering the container, so the --cluster-id must be provided,
 	// enable_persistent_histories must be true, and OCM must be configured
 	// for the user (outside the container)
-	if featureEnabled("persistent-histories") && viper.GetBool("enable_persistent_histories") {
-		if persistentHistories.DeprecatedConfig() && cluster != "" {
+	if featureEnabled("persistent-histories") {
+		if cluster != "" {
 			persistentHistoriesConfig, err := persistentHistories.New(home, cluster)
 			if err != nil {
 				return o, err
 			}
-			for k, v := range persistentHistoriesConfig.Env {
-				c.Envs[k] = v
-			}
+			maps.Copy(c.Envs, persistentHistoriesConfig.Env)
 			c.Volumes = append(c.Volumes, persistentHistoriesConfig.Mounts...)
 		}
 	}


### PR DESCRIPTION
I couldn't get persistent histories to work. The logic around enabling it was weird, on one hand we say it's enabled by default but on the other it still required an env var.

I've removed that check and made it enabled by default.

Additionally, I hid the persistent cluster directory within the home directory inside the container. Just felt weird seeing the new directory there.