### PR TITLE
Volume Refactor

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,8 +83,7 @@ and other Red Hat SRE tools`,
 		cmd.SilenceUsage = true
 
 		// Append any volumes passed in as flags to the volumes slice from the config
-		configurationVolumes := viper.GetStringSlice("volumes")
-		viper.Set("volumes", append(configurationVolumes, vols...))
+		viper.Set("vols", vols)
 
 		o, err := ocmcontainer.New(
 			cmd,

--- a/docs/example_config.yaml
+++ b/docs/example_config.yaml
@@ -23,9 +23,9 @@ env:
   # equivelant of `podman run -e SOME_SECRET_TOKEN`
   - name: SOME_SECRET_TOKEN
 
-# volumes contains a list of local directories to pass
+# volumeMounts contains a list of local directories to pass
 # into the container as additional volumes.
-volumes:
+volumeMounts:
   - /path/to/local/dir:/root/dir
 
 # Individual feature configuration

--- a/pkg/ocmcontainer/envs.go
+++ b/pkg/ocmcontainer/envs.go
@@ -18,6 +18,8 @@ var skippedKeys = []string{
 	"environment",
 	"volume",
 	"volumes",
+	"volumemounts",
+	"vols",
 }
 
 // ocmContainerEnvs returns a map of environment variables for a standard ocm-container env


### PR DESCRIPTION
Resolves #400 - allows bind mounts to be passed as strings but gives us the flexibility to change this at a later date to ALSO include maps to more sophisticated volume mounts if we need them.