### PR TITLE
Fixes the CI build release job to build both archs

### DIFF
--- a/.ci/release-build.sh
+++ b/.ci/release-build.sh
@@ -12,38 +12,31 @@ fi
 # as it is already set in the environment. The Makefile will use it if it exists.
 # Leaving it out here helps to potentially avoid issues with the token being exposed.
 
-# Cleanup any existing manifests
-make remove-manifests
-
-# Build the images
-# arm64 is not supported at this time, so we only build amd64
-# Multiple architectures can be specified at once by passing a comma-separated list
-# Example: ARCH="amd64,arm64"
-
-ARCH="amd64"
-echo "Building micro image for architecture: ${ARCH}"
-make ARCHITECTURE=${ARCH} build-micro
-make ARCHITECTURE=${ARCH} tag-micro
-
-# Allow cache for minimal and full
-# Full cache is invalidated from the micro build
-# and this will allow us to re-use layers from these builds
-# without unintentionally caching previous builds
-echo "Building minimal image for architecture: ${ARCH}"
-make CACHE="" build-minimal
-make ARCHITECTURE=${ARCH} tag-minimal
-
-echo "Building full image for architecture: ${ARCH}"
-make CACHE="" build-full
-make ARCHITECTURE=${ARCH} tag-full
-
 make registry-login
 
-# Push the images
-for ARCH in amd64; do
+# Build and push the images
+for ARCH in amd64 arm64; do
+
+    echo "Building micro image for architecture: ${ARCH}"
+    make ARCHITECTURE=${ARCH} build-micro
+    make ARCHITECTURE=${ARCH} tag-micro
+
+    # Allow cache for minimal and full
+    # Full cache is invalidated from the micro build
+    # and this will allow us to re-use layers from these builds
+    # without unintentionally caching previous builds
+    echo "Building minimal image for architecture: ${ARCH}"
+    make CACHE="" ARCHITECTURE=${ARCH} build-minimal
+    make ARCHITECTURE=${ARCH} tag-minimal
+
+    echo "Building full image for architecture: ${ARCH}"
+    make CACHE="" ARCHITECTURE=${ARCH} build-full
+    make ARCHITECTURE=${ARCH} tag-full
+
     echo "Pushing images for architecture: ${ARCH}"
     make ARCHITECTURE=${ARCH} push-all
 done
 
-# Skipping the manifest steps as we're not currently building arm64 images
+make remove-manifests
+make build-latest-manifests
 make push-manifests

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,13 @@ define push_manifest
 	${CONTAINER_ENGINE} manifest push $(IMAGE_URI)/$(1):latest
 endef
 
+# Helper macro: $(call build_manifest_target,<image name>,<tag>)
+define build_manifest_target
+    ${CONTAINER_ENGINE} manifest create $(IMAGE_URI)/$(1):$(2)
+	${CONTAINER_ENGINE} manifest add $(IMAGE_URI)/$(1):$(2) containers-storage:$(IMAGE_URI)/$(1):latest-arm64
+	${CONTAINER_ENGINE} manifest add $(IMAGE_URI)/$(1):$(2) containers-storage:$(IMAGE_URI)/$(1):latest-amd64
+endef
+
 # Helper macro: $(call remove_manifest,<image name>
 # Removes the manifest for the specified image name
 # The `|| true` ensures that if the manifest does not exist, the command does not fail
@@ -312,6 +319,12 @@ remove-manifests:
 	$(call remove_manifest,$(IMAGE_NAME)-micro)
 	$(call remove_manifest,$(IMAGE_NAME)-minimal)
 	$(call remove_manifest,$(IMAGE_NAME))
+
+.PHONY: build-latest-manifests
+build-latest-manifests:
+	$(call build_manifest_target,$(IMAGE_NAME)-micro,latest)
+	$(call build_manifest_target,$(IMAGE_NAME)-minimal,latest)
+	$(call build_manifest_target,$(IMAGE_NAME),latest)
 
 .PHONY: push-manifests push-manifest-all push-manifest-micro push-manifest-minimal push-manifest-full
 push-manifest-all:


### PR DESCRIPTION
Now builds and pushes a single manifest with both architectures.

We _may_ need to refactor this - emulated builds take a LOOOONNNGGG time. Approximately an hour on a t3.xlarge machine to build the arm64 variant.

We could just feed that into pipelines and ensure that the builds happen on the nodes of the correct architecture, and then upload those `ocm-container-micro:latest-arm64` type builds right to quay, and then have an additional pipeline job that just builds the manifest from those images.

So it would look something like this:

```
                    [build amd64]
                 //               \\
[build-kickoff]                       [build-manifest]
                 \\               //
                    [build arm64]
```

But we can cross that bridge if/when we need to.

Resolves #381