### PR TITLE
Add configurable volume mount options with SELinux support

### DIFF
--- a/docs/example_config.yaml
+++ b/docs/example_config.yaml
@@ -134,6 +134,11 @@ features:
     # to ~/.config/gcloud
     config_file: .config/gcloud
 
+    # Optional mount directive to mount the config directory
+    # read-only or read-write. Defaults to `ro`.
+    # Accepted values are `ro`, `rw`, `z`, `Z`, `ro,z`, `ro,Z`, `rw,z`, `rw,Z`
+    config_mount: ro
+
 
   # The Image Cache integration provides persistent container image
   # caching, improving startup times by reusing previously pulled images
@@ -160,9 +165,9 @@ features:
     # to ~/.jira/.config.yml
     config_file: .jira/.config.yml
 
-    # Optional mount directive to mount hte config file
+    # Optional mount directive to mount the config file
     # read-only or read-write. Defaults to `ro`.
-    # Accepted values are `ro` or `rw`
+    # Accepted values are `ro`, `rw`, `z`, `Z`, `ro,z`, `ro,Z`, `rw,z`, `rw,Z`
     config_mount: ro
 
 
@@ -230,8 +235,8 @@ features:
     config_file: ~/.config/pagerduty-cli/config.json
 
     # Optional mount option directive to mount the config file
-    # read-only or read-write. Defaults to `rw`. Accepted
-    # values are `rw` or `ro`
+    # read-only or read-write. Defaults to `rw`.
+    # Accepted values are `ro`, `rw`, `z`, `Z`, `ro,z`, `ro,Z`, `rw,z`, `rw,Z`
     config_mount: rw
 
 

--- a/docs/features/gcloud.md
+++ b/docs/features/gcloud.md
@@ -19,4 +19,18 @@ The following config options are provided for the gcloud functionality:
 features:
   gcloud:
     config_dir: /path/to/config/gcloud
+    config_mount: ro
 ```
+
+### Mount Options
+
+The `config_mount` option controls how the gcloud configuration directory is mounted into the container. Valid values are:
+
+- `ro` - Read-only (default)
+- `rw` - Read-write
+- `z` - SELinux private unshared label
+- `Z` - SELinux private shared label
+- `ro,z` - Read-only with SELinux private unshared label
+- `ro,Z` - Read-only with SELinux private shared label
+- `rw,z` - Read-write with SELinux private unshared label
+- `rw,Z` - Read-write with SELinux private shared label

--- a/docs/features/jira.md
+++ b/docs/features/jira.md
@@ -15,9 +15,22 @@ features:
 
 The following config options are provided for the JIRA functionality:
 
-```
+```yaml
 features:
   jira:
     config_file: /path/to/.jira/.config.yml
     config_mount: ro
 ```
+
+### Mount Options
+
+The `config_mount` option controls how the JIRA configuration file is mounted into the container. Valid values are:
+
+- `ro` - Read-only (default)
+- `rw` - Read-write
+- `z` - SELinux private unshared label
+- `Z` - SELinux private shared label
+- `ro,z` - Read-only with SELinux private unshared label
+- `ro,Z` - Read-only with SELinux private shared label
+- `rw,z` - Read-write with SELinux private unshared label
+- `rw,Z` - Read-write with SELinux private shared label

--- a/docs/features/pagerduty.md
+++ b/docs/features/pagerduty.md
@@ -11,12 +11,25 @@ features:
 ```
 
 ## Initial Setup
-In order to set up the Pagerduty CLI the first time, ensure that the config file exists first with `mkdir -p ~/.config/pagerduty-cli && touch ~/.config/pagerduty-cli/config.json`. You'll also need to mount the Pagerduty config file as writeable by setting the `pagerduty_dir_rw: true` configuration (or `export OCMC_PAGERDUTY_DIR_RW: true`) the first time. Once you've logged in to ocm-container, run `pd login` to do the initial setup.
+In order to set up the Pagerduty CLI the first time, ensure that the config file exists first with `mkdir -p ~/.config/pagerduty-cli && touch ~/.config/pagerduty-cli/config.json`. You'll also need to mount the Pagerduty config file as writeable by setting the `config_mount: rw` configuration the first time. Once you've logged in to ocm-container, run `pd login` to do the initial setup.
 
 You may then set the pagerduty feature config to be read-only on subsequent runs of ocm-container with:
 
-```
+```yaml
 features:
   pagerduty:
     config_mount: ro
 ```
+
+## Mount Options
+
+The `config_mount` option controls how the PagerDuty configuration file is mounted into the container. Valid values are:
+
+- `ro` - Read-only
+- `rw` - Read-write (default)
+- `z` - SELinux private unshared label
+- `Z` - SELinux private shared label
+- `ro,z` - Read-only with SELinux private unshared label
+- `ro,Z` - Read-only with SELinux private shared label
+- `rw,z` - Read-write with SELinux private unshared label
+- `rw,Z` - Read-write with SELinux private shared label

--- a/pkg/features/jira/jira.go
+++ b/pkg/features/jira/jira.go
@@ -49,6 +49,12 @@ func (cfg *config) validate() error {
 	validMountOptions := []string{
 		"ro",
 		"rw",
+		"z",
+		"Z",
+		"ro,z",
+		"ro,Z",
+		"rw,z",
+		"rw,Z",
 	}
 	if !slices.Contains(validMountOptions, cfg.MountOpts) {
 		return fmt.Errorf("invalid mount option. Valid options are %s", validMountOptions)
@@ -135,8 +141,9 @@ func (f *Feature) Initialize() (features.OptionSet, error) {
 		return opts, err
 	}
 	opts.AddVolumeMount(engine.VolumeMount{
-		Source:      jiraConfigFile,
-		Destination: jiraConfigFileDest,
+		Source:       jiraConfigFile,
+		Destination:  jiraConfigFileDest,
+		MountOptions: f.config.MountOpts,
 	})
 
 	return opts, nil

--- a/pkg/features/pagerduty/pagerduty.go
+++ b/pkg/features/pagerduty/pagerduty.go
@@ -39,6 +39,12 @@ func (cfg *config) validate() error {
 	validMountOptions := []string{
 		"ro",
 		"rw",
+		"z",
+		"Z",
+		"ro,z",
+		"ro,Z",
+		"rw,z",
+		"rw,Z",
 	}
 	if !slices.Contains(validMountOptions, cfg.MountOpts) {
 		return fmt.Errorf("invalid mount option. Valid options are %s", validMountOptions)


### PR DESCRIPTION
## Summary
- Adds configurable `config_mount` option to gcloud feature for SELinux support
- Updates mount option validation in gcloud, jira, and pagerduty features to support SELinux labels (`z`, `Z`) and combinations
- Fixes jira feature bug where `config_mount` was defined but not actually used

## Changes
- **gcloud**: Added `MountOpts` config field with validation and default `ro`
- **jira**: Added SELinux options to validation and fixed bug to actually use `config_mount`
- **pagerduty**: Added SELinux options to validation

## Valid Mount Options
- `ro` (read-only)
- `rw` (read-write)
- `z` (private SELinux label)
- `Z` (shared SELinux label)
- Combinations: `ro,z`, `ro,Z`, `rw,z`, `rw,Z`

## Example Configuration
```yaml
features:
  gcloud:
    enabled: true
    config_dir: ".config/gcloud"
    config_mount: "ro,z"  # For Fedora with SELinux
```

## Test plan
- [x] All feature tests pass
- [x] Manual validation of configuration options
- [ ] Test on Fedora with SELinux enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)