### PR TITLE
Fix test failures in ocmcontainer and engine packages

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -322,9 +322,15 @@ func parseRefToArgs(c ContainerRef) ([]string, error) {
 		args = append(args, c.BestEffortArgs...)
 	}
 
+	if c.Entrypoint != "" {
+		args = append(args, fmt.Sprintf("--entrypoint=%s", c.Entrypoint))
+	}
+
 	args = append(args, ttyToString(c.Tty, c.Interactive)...)
 
-	args = append(args, c.Image)
+	if c.Image != "" {
+		args = append(args, c.Image)
+	}
 
 	// This needs to come last because command is a positional argument
 	if c.Command != "" {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -106,17 +106,17 @@ func TestParseRefToArgs(t *testing.T) {
 		},
 		{
 			name:      "Tests image fqdn",
-			container: ContainerRef{Image: ContainerImage{Name: "imagename", Tag: "test"}},
+			container: ContainerRef{Image: "imagename:test"},
 			expected:  []string{"imagename:test"},
 		},
 		{
 			name:      "Tests image fqdn with reponame",
-			container: ContainerRef{Image: ContainerImage{Name: "imagename", Tag: "test", Repository: "openshift"}},
+			container: ContainerRef{Image: "openshift/imagename:test"},
 			expected:  []string{"openshift/imagename:test"},
 		},
 		{
 			name:      "Tests image fqdn with reponame and registry",
-			container: ContainerRef{Image: ContainerImage{Name: "imagename", Tag: "test", Repository: "openshift", Registry: "quay.io"}},
+			container: ContainerRef{Image: "quay.io/openshift/imagename:test"},
 			expected:  []string{"quay.io/openshift/imagename:test"},
 		},
 		{
@@ -187,10 +187,7 @@ func TestParseRefToArgs(t *testing.T) {
 			Command:         "my command to do something",
 			RemoveAfterExit: true,
 			Privileged:      true,
-			Image: ContainerImage{
-				Name: "test",
-				Tag:  "latest",
-			},
+			Image:           "test:latest",
 		}
 
 		args, err := parseRefToArgs(container)

--- a/pkg/ocmcontainer/ocmcontainer_test.go
+++ b/pkg/ocmcontainer/ocmcontainer_test.go
@@ -249,7 +249,7 @@ func TestCleanup(t *testing.T) {
 }
 
 func TestRegisterPreExecCleanupFunc(t *testing.T) {
-	o := &ocmContainer{
+	o := &Runtime{
 		preExecCleanupFuncs: []func(){},
 	}
 
@@ -264,7 +264,7 @@ func TestRegisterPreExecCleanupFunc(t *testing.T) {
 }
 
 func TestRegisterPostExecCleanupFunc(t *testing.T) {
-	o := &ocmContainer{
+	o := &Runtime{
 		postExecCleanupFuncs: []func(){},
 	}
 
@@ -303,7 +303,7 @@ func TestStopMethod(t *testing.T) {
 }
 
 func TestTrapInitialization(t *testing.T) {
-	o := &ocmContainer{
+	o := &Runtime{
 		trapped: false,
 	}
 
@@ -324,7 +324,7 @@ func TestTrapInitialization(t *testing.T) {
 
 func TestPreExecCleanup(t *testing.T) {
 	callCount := 0
-	o := &ocmContainer{
+	o := &Runtime{
 		preExecCleanupFuncs: []func(){
 			func() { callCount++ },
 			func() { callCount++ },
@@ -340,7 +340,7 @@ func TestPreExecCleanup(t *testing.T) {
 
 func TestPostExecCleanup(t *testing.T) {
 	callCount := 0
-	o := &ocmContainer{
+	o := &Runtime{
 		postExecCleanupFuncs: []func(){
 			func() { callCount++ },
 			func() { callCount++ },


### PR DESCRIPTION
## Summary

This PR fixes test failures in the `pkg/ocmcontainer` and `pkg/engine` packages:

* Fix ocmcontainer tests to use `Runtime` struct instead of undefined `ocmContainer`
* Fix engine tests to use string `Image` field instead of `ContainerImage` struct  
* Add missing `Entrypoint` field handling in `parseRefToArgs`
* Add empty check for `Image` field to prevent appending empty strings

All tests now pass successfully.

## Test plan

- [x] Run `make test` - all tests pass
- [x] Verified ocmcontainer package tests pass
- [x] Verified engine package tests pass
- [x] No regressions in other test packages

🤖 Generated with Claude Code