### PR TITLE
removes OCMC var checks in console override

### DIFF
--- a/utils/bin/cluster-console
+++ b/utils/bin/cluster-console
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
 
-if [ "${OCMC_ENGINE}" != "podman" ]
-then
-  echo "Cluster console inside OCM Container is currently only supported with Podman"
-  exit 1
-fi
-
-if [ "${OCMC_DISABLE_CONSOLE_PORT}" == "true " ]
-then
-  echo "Cluster console port disabled: OCMC_DISABLE_CONSOLE_PORT == true"
-  exit 1
-fi
-
 # if the file doesn't exist, or is empty, exit
 if [ ! -f /tmp/portmap ] || [ ! -s /tmp/portmap ]
 then


### PR DESCRIPTION
Removes the OCMC env var checks in the ocm-backplane console command override.