### PR TITLE
Add `socat` for AWS SSM port forwarding

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -150,6 +150,7 @@ RUN dnf --assumeyes --nodocs install \
       python3 \
       python3-pip \
       rsync \
+      socat \
       tar \
       vim-enhanced \
       wget \


### PR DESCRIPTION
Add the `socat` package to assist with HCP AWS SSM Port forwarding, as the SSM cli tool does not allow binding to 0.0.0.0, which is required for accessing the portmapped port from ocm-container via your localhost browser.

This only applies to the "full" image - minimal images do not need this change.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>