### PR TITLE
Change to use podman secret mounts for GITHUB_TOKEN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ PROJECT_LABELS := \
 #--label io.openshift.managed.description=\'$(PROJECT_SUMMARY)\'
 
 ifdef GITHUB_TOKEN
-GITHUB_BUILD_ARGS     := --build-arg GITHUB_TOKEN=$(GITHUB_TOKEN)
+GITHUB_BUILD_ARGS     := --secret=id=GITHUB_TOKEN,env=GITHUB_TOKEN
 endif
 
 # Architecture detection

--- a/utils/dockerfile_assets/github_dl.py
+++ b/utils/dockerfile_assets/github_dl.py
@@ -34,21 +34,38 @@ def validate_binary(binary, checksum, raw_algorithm="sha256") -> bool:
     return True
 
 
-def get_url_with_authentication(url, token=None, additional_headers=None) -> requests.Response:
+def get_url_with_authentication(url, token=None, additional_headers=None, retry=0, max_retries=5) -> requests.Response:
+    if retry > max_retries:
+        print("max retries reached. Exiting")
+        return None
+
     headers = {}
     if token:
         headers["Authorization"] = f"Bearer {token}"
 
     if additional_headers:
         headers.update(additional_headers)
-    
-    response = requests.get(url, headers=headers)
-    
-    if response.status_code != 200:
-        print(f"Failed to fetch data from {url}: {response.status_code} {response.text}")
-        return None
 
-    return response
+    response = requests.get(url, headers=headers)
+
+    ## If it's a 200, return immediately
+    ## If it's a 500+ error code, this is a GitHub issue and we
+    ## can potentially retry depending on whether this is a
+    ## transient error from GH or not.
+    ## Otherwise, it's a 400 error and that's a problem with the
+    ## request itself and a retry won't help anything.
+    if response.status_code == 200:
+        return response
+
+    if response.status_code >= 500:
+        print(f"Got {response.status_code}. Backing-off and retrying...")
+        retry+=1
+        time.sleep(3*retry)
+
+        return get_url_with_authentication(url, token, additional_headers, retry, max_retries)
+
+    print(f"Failed to fetch data from {url}: {response.status_code} {response.text}")
+    return None
 
 
 def list_assets(url, token=None) -> list:
@@ -169,12 +186,23 @@ def main():
     download_parser.add_argument("--checksum_algorithm", default="sha256", help="Checksum algorithm to use (default: 'sha256') ")
     download_parser.add_argument("--platform", required=True, help="Platform to download assets for (e.g., 'amd64')")
     args = parser.parse_args()
+    args.token = None
+
+    secretMount = "/run/secrets/GITHUB_TOKEN"
+    if os.path.isfile(secretMount):
+        with open(secretMount) as f:
+            args.token = f.read()
+
+    tokenMount = "/run/secrets/GITHUB_TOKEN/token"
+    if os.path.isfile(tokenMount):
+        with open(tokenMount) as f:
+            args.token = f.read()
 
     if os.environ.get("GITHUB_TOKEN"):
         args.token = os.environ["GITHUB_TOKEN"]
-    else:
-        args.token = None
-        print("No GITHUB_TOKEN found in environment variables. Proceeding without authentication.")
+
+    if args.token is None:
+        print("No GITHUB_TOKEN found in environment variables nor secret. Proceeding without authentication.")
 
     if args.command == "quota":
         errors = get_quota(getattr(args, 'token', None))


### PR DESCRIPTION
Should be a drop-in replacement for anyone using `make build-full-local` or other Makefile targets.

Otherwise allows Konflux builds to mount a secret in the same way as local builds.

Additionally Github was throwing some 504 errors so I added a small bit of retry logic to the GH downloader python script.