### PR TITLE
bump the image and go version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.redhat.io/ubi10/ubi:10.1-1763341459
+ARG BASE_IMAGE=registry.redhat.io/ubi10/ubi:10.1-1769418072
 FROM ${BASE_IMAGE} as tools-base
 ARG OUTPUT_DIR="/opt"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/ocm-container
 
-go 1.24.11
+go 1.25.5
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
Bumping the base image and go version to help resolving the CVEs as noted in https://issues.redhat.com/browse/SREP-2853 