### PR TITLE
update go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/ocm-container
 
-go 1.24.11
+go 1.25.5
 
 require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d


### PR DESCRIPTION
Updates go version from 1.24.11 to 1.25.5