### PR TITLE
fix: prevent repeated cluster login on unreachable clusters

### DIFF
--- a/utils/bashrc.d/26-sre-login.bashrc
+++ b/utils/bashrc.d/26-sre-login.bashrc
@@ -4,5 +4,11 @@
 # This prevents another attempt at login if using a terminal multiplexer
 if ! oc config current-context &>/dev/null && [ -z "$SKIP_CLUSTER_LOGIN" ] && [ -n "$CLUSTER_ID" ]
 then
-  sre-login "$CLUSTER_ID"
+  if [ -f "${HOME}/.session/sre-login-attempted" ]; then
+    echo "Skipping automatic cluster login (previous attempt detected). Run 'sre-login $CLUSTER_ID' to retry manually."
+  else
+    mkdir -p "${HOME}/.session"
+    touch "${HOME}/.session/sre-login-attempted"
+    sre-login "$CLUSTER_ID"
+  fi
 fi

--- a/utils/bashrc.d/99-osdctl-cluster-context.bashrc
+++ b/utils/bashrc.d/99-osdctl-cluster-context.bashrc
@@ -1,7 +1,9 @@
 # shellcheck shell=bash
 # show cluster context at login
 
-if [ -n "$CLUSTER_ID" ] && [ -z "$SKIP_CLUSTER_CONTEXT" ]; then
+if [ -n "$CLUSTER_ID" ] && [ -z "$SKIP_CLUSTER_CONTEXT" ] && [ ! -f "${HOME}/.session/osdctl-context-attempted" ]; then
+	mkdir -p "${HOME}/.session"
+	touch "${HOME}/.session/osdctl-context-attempted"
 	echo "Checking the context on $CLUSTER_ID"
 	osdctl cluster context --cluster-id "$CLUSTER_ID"
 fi

--- a/utils/bin/sre-login
+++ b/utils/bin/sre-login
@@ -59,4 +59,9 @@ cluster_id=$(jq -r '.id' <<< "$clusterjson")
 cluster_listening=$(jq -r '.api.listening' <<< "$clusterjson")
 
 # Login to the Cluster
-exec ocm backplane login ${cluster_id}
+ocm backplane login ${cluster_id}
+rc=$?
+if [ $rc -eq 0 ]; then
+  rm -f "${HOME}/.session/sre-login-attempted"
+fi
+exit $rc


### PR DESCRIPTION
## Summary
- When a cluster is unreachable, `sre-login` fails but every new bash shell (tmux panes, subshells) retries login automatically, causing the "Logging into cluster..." delay each time
- Uses a `~/.session/sre-login-attempted` marker file so automatic login is only attempted once per container session
- Applies the same once-only treatment to `osdctl cluster context` via `~/.session/osdctl-context-attempted`
- Users can still retry manually with `sre-login $CLUSTER_ID` at any time; successful manual login clears the marker
- Marker files stored in `~/.session/` rather than `/tmp/` for better container engine compatibility

## Test plan
- [ ] Launch ocm-container with a valid, reachable cluster — confirm login works normally and subsequent shells skip via kubeconfig
- [ ] Launch ocm-container with an unreachable cluster — confirm login is attempted once, subsequent shells print skip message instead of retrying
- [ ] After a failed auto-login, run `sre-login $CLUSTER_ID` manually — confirm manual retry works and marker is cleared on success
- [ ] Verify `osdctl cluster context` only runs once per container session
- [ ] Verify `~/.session/` directory is created automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)