### PR TITLE
fix: remove stale OCMC var checks from blackbox-exporter

### DIFF
--- a/utils/bin/blackbox-exporter
+++ b/utils/bin/blackbox-exporter
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
 
-if [ "${OCMC_ENGINE}" != "podman" ]
-then
-  echo "Blackbox exporter inside OCM Container is currently only supported with Podman"
-  exit 1
-fi
-
-if [ "${OCMC_DISABLE_CONSOLE_PORT}" == "true " ]
-then
-	echo "Cluster console port (used by blackbox-exporter) disabled: OCMC_DISABLE_CONSOLE_PORT == true"
-  exit 1
-fi
-
 # if the file doesn't exist, or is empty, exit
 if [ ! -f /tmp/portmap ] || [ ! -s /tmp/portmap ]
 then


### PR DESCRIPTION
## Summary
- Removes `OCMC_ENGINE` and `OCMC_DISABLE_CONSOLE_PORT` checks from `blackbox-exporter`, matching the fix already applied to `cluster-console` in #424
- These env vars are no longer injected into the container since `envs.go` was removed in 4ce8961, so the checks always fail

## Context
The `ocmContainerEnvs()` function in `pkg/ocmcontainer/envs.go` used to auto-inject all viper config keys as `OCMC_*` env vars into the container. When that was removed in 4ce8961, `cluster-console` was fixed in #424 (0ec08f9) by removing its identical checks, but `blackbox-exporter` was missed.

## Test plan
- [x] Run `blackbox-exporter` inside ocm-container using podman — should no longer error with "only supported with Podman"
- [x] Verify `/tmp/portmap` check still gates execution correctly when ports aren't mapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary runtime environment restrictions from the blackbox-exporter script, allowing execution in broader configurations and reducing prerequisite requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->