### PR TITLE
feat(jira): pass through JIRA_EMAIL env var to container

### DIFF
--- a/docs/features/jira.md
+++ b/docs/features/jira.md
@@ -3,7 +3,7 @@
 This assumes that the JIRA CLI tool is already set up and working outside of the container.
 
 * No additional configuration required if the configuration file is in the standard location ($HOME/.jira/.config.yml)
-* Additionally expects the `JIRA_API_TOKEN` and `JIRA_AUTH_TYPE` env vars to be set.
+* Additionally checks `JIRA_API_TOKEN`, optional `JIRA_AUTH_TYPE` (defaults to `bearer` when token is set), and optional `JIRA_EMAIL` (passed through when set).
 * Can be explicitly disabled with the `--no-jira` flag or with the following yaml in the ocm-container config file:
 ```
 features:

--- a/docs/occ-migration.md
+++ b/docs/occ-migration.md
@@ -122,7 +122,10 @@ To disable this functionality or change the config directory, the following conf
 ```
 
 #### JIRA
-By default, the JIRA integration looks for both the `JIRA_API_TOKEN` and `JIRA_AUTH_TYPE` environment variables, as well as a configuration file located at `~/.jira/.config.yml`. If the env vars are present, the config file is located and mounted. If the config file is not present, the env vars are still loaded. If the `JIRA_API_TOKEN` env var is not present, nothing is loaded. If the `JIRA_API_TOKEN` env var is present but the `JIRA_AUTH_TYPE` env var is not, `JIRA_AUTH_TYPE` will default to `bearer` and the config file will be attempted to be found.
+By default, the JIRA integration checks `JIRA_API_TOKEN`, `JIRA_AUTH_TYPE`, and `JIRA_EMAIL`, and also attempts to mount `~/.jira/.config.yml`.
+If `JIRA_API_TOKEN` is set, it is passed through; if `JIRA_AUTH_TYPE` is missing, it defaults to `bearer`.
+`JIRA_EMAIL` is passed through independently when set (for tools such as `osdctl`), regardless of token presence.
+If the config file is missing, env var passthrough behavior is unchanged.
 
 The following configuration yaml changes have been made:
 

--- a/pkg/features/jira/jira.go
+++ b/pkg/features/jira/jira.go
@@ -18,6 +18,7 @@ const (
 	FlagHelpMessage = "Disables jira functionality"
 
 	jiraEnvTokenKey           = "JIRA_API_TOKEN"
+	jiraEnvEmailKey           = "JIRA_EMAIL"
 	jiraAuthTypeKey           = "JIRA_AUTH_TYPE"
 	defaultAuthType           = "bearer"
 	defaultConfigFileLocation = ".config/.jira/.config.yml"
@@ -134,6 +135,10 @@ func (f *Feature) Initialize() (features.OptionSet, error) {
 		} else {
 			opts.AddEnvKeyVal(jiraAuthTypeKey, defaultAuthType)
 		}
+	}
+
+	if os.Getenv(jiraEnvEmailKey) != "" {
+		opts.AddEnvKey(jiraEnvEmailKey)
 	}
 
 	jiraConfigFile, err := f.statConfigFileLocations()

--- a/pkg/features/jira/jira_test.go
+++ b/pkg/features/jira/jira_test.go
@@ -12,6 +12,7 @@ import (
 var _ = Describe("Pkg/Features/Jira/Jira", func() {
 	originalAPITokenEnvVal := ""
 	originalAuthTypeEnvVal := ""
+	originalEmailEnvVal := ""
 
 	BeforeEach(func() {
 		viper.Reset()
@@ -21,8 +22,12 @@ var _ = Describe("Pkg/Features/Jira/Jira", func() {
 		if os.Getenv("JIRA_AUTH_TYPE") != "" {
 			originalAuthTypeEnvVal = os.Getenv("JIRA_AUTH_TYPE")
 		}
+		if os.Getenv("JIRA_EMAIL") != "" {
+			originalEmailEnvVal = os.Getenv("JIRA_EMAIL")
+		}
 		os.Unsetenv("JIRA_API_TOKEN")
 		os.Unsetenv("JIRA_AUTH_TYPE")
+		os.Unsetenv("JIRA_EMAIL")
 	})
 
 	AfterEach(func() {
@@ -32,6 +37,11 @@ var _ = Describe("Pkg/Features/Jira/Jira", func() {
 		}
 		if originalAuthTypeEnvVal != "" {
 			os.Setenv("JIRA_AUTH_TYPE", originalAuthTypeEnvVal)
+		}
+		if originalEmailEnvVal != "" {
+			os.Setenv("JIRA_EMAIL", originalEmailEnvVal)
+		} else {
+			os.Unsetenv("JIRA_EMAIL")
 		}
 	})
 
@@ -317,6 +327,92 @@ var _ = Describe("Pkg/Features/Jira/Jira", func() {
 			opts, err := f.Initialize()
 			Expect(err).To(BeNil())
 			Expect(opts.Envs).To(HaveLen(0))
+		})
+
+		It("Adds JIRA_EMAIL env var when set", func() {
+			os.Setenv("JIRA_EMAIL", "user@example.com")
+			afs := afero.Afero{Fs: afero.NewMemMapFs()}
+			configFile := "/path/to/.config/.jira/.config.yml"
+			err := afs.WriteFile(configFile, []byte("{}"), 0644)
+			Expect(err).To(BeNil())
+
+			f := Feature{
+				afs: &afs,
+				config: &config{
+					Enabled:   true,
+					FilePath:  configFile,
+					MountOpts: "ro",
+				},
+			}
+
+			opts, err := f.Initialize()
+			Expect(err).To(BeNil())
+			findEmail := false
+			for _, env := range opts.Envs {
+				if env.Key == "JIRA_EMAIL" {
+					findEmail = true
+				}
+			}
+			Expect(findEmail).To(Equal(true))
+		})
+
+		It("Adds JIRA_EMAIL env var alongside JIRA_API_TOKEN when both are set", func() {
+			os.Setenv("JIRA_API_TOKEN", "test-token")
+			os.Setenv("JIRA_EMAIL", "user@example.com")
+			afs := afero.Afero{Fs: afero.NewMemMapFs()}
+			configFile := "/path/to/.config/.jira/.config.yml"
+			err := afs.WriteFile(configFile, []byte("{}"), 0644)
+			Expect(err).To(BeNil())
+
+			f := Feature{
+				afs: &afs,
+				config: &config{
+					Enabled:   true,
+					FilePath:  configFile,
+					MountOpts: "ro",
+				},
+			}
+
+			opts, err := f.Initialize()
+			Expect(err).To(BeNil())
+			findAPIToken := false
+			findEmail := false
+			for _, env := range opts.Envs {
+				if env.Key == "JIRA_API_TOKEN" {
+					findAPIToken = true
+				}
+				if env.Key == "JIRA_EMAIL" {
+					findEmail = true
+				}
+			}
+			Expect(findAPIToken).To(Equal(true))
+			Expect(findEmail).To(Equal(true))
+		})
+
+		It("Does not add JIRA_EMAIL env var when not set", func() {
+			afs := afero.Afero{Fs: afero.NewMemMapFs()}
+			configFile := "/path/to/.config/.jira/.config.yml"
+			err := afs.WriteFile(configFile, []byte("{}"), 0644)
+			Expect(err).To(BeNil())
+
+			f := Feature{
+				afs: &afs,
+				config: &config{
+					Enabled:   true,
+					FilePath:  configFile,
+					MountOpts: "ro",
+				},
+			}
+
+			opts, err := f.Initialize()
+			Expect(err).To(BeNil())
+			findEmail := false
+			for _, env := range opts.Envs {
+				if env.Key == "JIRA_EMAIL" {
+					findEmail = true
+				}
+			}
+			Expect(findEmail).To(Equal(false))
 		})
 
 		DescribeTable("Mounts with various mount options",


### PR DESCRIPTION
## Summary
- Pass `JIRA_EMAIL` environment variable through to the container when set on the host
- `osdctl` now requires `JIRA_EMAIL` for Jira connectivity, causing errors on container launch without it
- Follows the same passthrough pattern used for `JIRA_API_TOKEN` and `JIRA_AUTH_TYPE`

## Test plan
- [x] Unit tests added and passing (`go test ./pkg/features/jira/ -v` — 39/39 pass)
- [x] Set `JIRA_EMAIL` on host, launch ocm-container, verify `echo $JIRA_EMAIL` shows the value inside
- [x] Launch without `JIRA_EMAIL` set, verify no errors from the passthrough itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JIRA integration now accepts an optional JIRA_EMAIL environment variable; JIRA_API_TOKEN controls whether JIRA support is loaded and JIRA_AUTH_TYPE is optional (defaults to "bearer" when a token is present).

* **Documentation**
  * CLI docs and migration guide updated to describe email passthrough, token-driven loading, and default auth-type behavior.

* **Tests**
  * Tests expanded to cover JIRA_EMAIL handling and to preserve/restore environment state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->