### PR TITLE
feat: add vault OIDC callback port to ports feature

### DIFF
--- a/docs/example_config.yaml
+++ b/docs/example_config.yaml
@@ -87,6 +87,20 @@ ports:
     # Default: 9999
     port: 9999
 
+  # Vault OIDC callback port configuration
+  # This port is used for HashiCorp Vault OIDC authentication callbacks
+  # when running `vault login -method=oidc` inside the container
+  vault:
+    # Enable or disable vault OIDC callback port forwarding
+    # Default: true
+    enabled: true
+
+    # Container port to bind for vault OIDC callback
+    # The actual host port will be randomly assigned by the container engine
+    # and written to /tmp/vault_callback_port inside the container
+    # Default: 8250
+    port: 8250
+
 
 # Individual feature configuration
 features:
@@ -200,7 +214,7 @@ features:
 
 
   # The OSDCTL integration mounts your osdctl configuration
-  # and optional vault token into the container
+  # into the container
   osdctl:
     # Enable or disable the osdctl integration
     # Default: true, switch to false to disable.
@@ -211,19 +225,16 @@ features:
     # Defaults to '.config/osdctl' (relative to $HOME if not absolute)
     config_file: .config/osdctl
 
-    # Path to the vault token file (optional)
-    # Defaults to '.vault-token' (relative to $HOME if not absolute)
-    token_file: .vault-token
-
     # Optional mount option directive for the config file
     # read-only or read-write. Defaults to `ro`. Accepted
     # values are `rw` or `ro`
     config_mount_options: ro
 
-    # Optional mount option directive for the token file
-    # read-only or read-write. Defaults to `rw`. Accepted
-    # values are `rw` or `ro`
-    token_mount_options: rw
+    # DEPRECATED: token_file and token_mount_options are no longer used.
+    # Vault token mounting via single-file bind mount breaks vault's
+    # atomic rename during OIDC re-authentication. Vault authentication
+    # is now handled via the ports feature (dynamic port 8250 mapping)
+    # and osdctl manages the token in-process.
 
 
   # The PagerDuty integration mounts a PagerDuty config file

--- a/docs/features/osdctl.md
+++ b/docs/features/osdctl.md
@@ -1,6 +1,6 @@
 # OSDCTL Configuration
 
-This feature allows you to mount your osdctl configuration and vault token into the container.
+This feature mounts your osdctl configuration into the container.
 
 * Must be explicitly configured with a config file path
 * Can be disabled with the `--no-osdctl` flag or with the following yaml in the ocm-container config file:
@@ -23,25 +23,21 @@ features:
     # Defaults to '.config/osdctl' (relative to $HOME if not absolute)
     config_file: .config/osdctl
 
-    # Path to the vault token file
-    # This is optional - the feature will work without it
-    # Defaults to '.vault-token' (relative to $HOME if not absolute)
-    token_file: .vault-token
-
     # Mount options for the config file - either 'ro' (read-only) or 'rw' (read-write)
     # Defaults to 'ro'
     config_mount_options: ro
-
-    # Mount options for the token file - either 'ro' (read-only) or 'rw' (read-write)
-    # Defaults to 'rw'
-    token_mount_options: rw
 ```
 
-The config file will be mounted at `/root/.config/osdctl` inside the container, and the vault token (if present) will be mounted at `/root/.vault-token`.
+The config file will be mounted at `/root/.config/osdctl` inside the container.
+
+## Vault Token
+
+The `token_file` and `token_mount_options` settings are deprecated. Single-file bind mounts of `~/.vault-token` break vault's atomic rename during OIDC re-authentication inside the container.
+
+Vault OIDC authentication is now handled via the [ports feature](ports.md), which dynamically maps port 8250 for the OIDC callback. osdctl manages the vault token in-process after authentication, avoiding the need to mount the token file.
 
 ## Notes
 
-* Both absolute and `$HOME`-relative paths are supported for `config_file` and `token_file`
-* The vault token file is optional - if it doesn't exist, only the config file will be mounted
+* Both absolute and `$HOME`-relative paths are supported for `config_file`
 * If the config file is not found and you have provided configuration, the feature will exit with an error
 * If you haven't provided any configuration for this feature, it will be silently disabled

--- a/docs/features/ports.md
+++ b/docs/features/ports.md
@@ -55,6 +55,15 @@ The console port is designed for accessing web-based consoles or services:
 - **Purpose**: General-purpose port for the `ocm backplane console` command to access the cluster's OCP console
 - **Port map file**: After container starts, the actual mapped port is written to `/tmp/portmap` inside the container
 
+### Vault OIDC Callback Port
+
+The vault port is used for HashiCorp Vault OIDC authentication callbacks:
+
+- **Default container port**: 8250
+- **Purpose**: Receives OIDC callback from the browser during `vault login -method=oidc` authentication
+- **Port map file**: After container starts, the actual mapped host port is written to `/tmp/vault_callback_port` inside the container
+- **Multi-container support**: Because the host port is dynamically assigned, multiple ocm-container instances can run simultaneously without port conflicts
+
 ## Configuration Examples
 
 ### Default Configuration
@@ -64,6 +73,26 @@ Use default settings (console port 9999):
 ```yaml
 ports:
   enabled: true
+```
+
+### Custom Vault Port
+
+Change the vault OIDC callback port to 9250:
+
+```yaml
+ports:
+  vault:
+    port: 9250
+```
+
+### Disable Vault Port
+
+Disable only the vault port while keeping console enabled:
+
+```yaml
+ports:
+  vault:
+    enabled: false
 ```
 
 ### Custom Console Port
@@ -160,7 +189,6 @@ Common reasons for port mapping failures:
 The ports feature is designed to be extensible. Future versions may include:
 
 - Support for additional named ports (e.g., prometheus, alertmanager, thanos, etc.)
-- Automatic port conflict resolution
 
 ## Benefits
 

--- a/docs/occ-migration.md
+++ b/docs/occ-migration.md
@@ -151,7 +151,7 @@ This feature mounts the ops-sop/v4/utils directory into the container at `/root/
 Note: The `source_dir` configuration is required for the feature to work - there is no default value.
 
 #### OSDCTL
-This feature mounts your osdctl configuration file and optional vault token into the container. Unlike the previous implementation, this feature must now be explicitly configured with a config file path. The following configuration yaml changes have been made:
+This feature mounts your osdctl configuration file into the container. Unlike the previous implementation, this feature must now be explicitly configured with a config file path. The following configuration yaml changes have been made:
 
 ```yaml
 .no_osdctl (bool) -> .features.osdctl.enabled (bool)
@@ -160,12 +160,12 @@ This feature mounts your osdctl configuration file and optional vault token into
 New configuration options:
 ```yaml
 .features.osdctl.config_file (file path) - defaults to '.config/osdctl'
-.features.osdctl.token_file (file path) - defaults to '.vault-token'
 .features.osdctl.config_mount_options (iota 'rw'|'ro') - defaults to 'ro'
-.features.osdctl.token_mount_options (iota 'rw'|'ro') - defaults to 'rw'
 ```
 
-Note: The `config_file` must exist for the feature to work. The `token_file` is optional.
+Note: The `config_file` must exist for the feature to work.
+
+The `token_file` and `token_mount_options` settings are deprecated. Vault token mounting via single-file bind mount broke vault's atomic rename during OIDC re-authentication. Vault OIDC callback port mapping is now handled by the ports feature, and osdctl manages the token in-process.
 
 #### PagerDuty
 The `pd-cli` (pagerduty-cli) tool has been removed from the container as it is no longer maintained. The PagerDuty feature has been updated to allow token mounting for use with other PagerDuty tools.

--- a/pkg/features/osdctl/osdctl.go
+++ b/pkg/features/osdctl/osdctl.go
@@ -123,16 +123,12 @@ func (f *Feature) Initialize() (features.OptionSet, error) {
 		MountOptions: f.config.ConfigMountOptions,
 	})
 
-	// Optionally mount the vault token file if it exists
-	tokenPath, err := f.statFileLocations(f.config.TokenFile)
-	if err == nil {
-		opts.AddVolumeMount(engine.VolumeMount{
-			Source:       tokenPath,
-			Destination:  "/root/" + vaultTokenFile,
-			MountOptions: f.config.TokenMountOptions,
-		})
-	} else {
-		log.Debugf("vault token file not found, skipping mount: %v", err)
+	// Vault token file mounting is deprecated. Single-file bind mounts
+	// break vault's atomic rename when re-authenticating inside the
+	// container. Use the ports feature for vault OIDC callback port
+	// mapping and let osdctl manage the token in-process instead.
+	if f.config.TokenFile != "" {
+		log.Debugf("vault token file mount is deprecated and will be ignored: %s", f.config.TokenFile)
 	}
 
 	return opts, nil

--- a/pkg/features/osdctl/osdctl_test.go
+++ b/pkg/features/osdctl/osdctl_test.go
@@ -182,40 +182,7 @@ var _ = Describe("Pkg/Features/Osdctl/Osdctl", func() {
 	})
 
 	Context("Tests Feature.Initialize()", func() {
-		It("Returns OptionSet with volume mounts when both config and token files exist", func() {
-			afs := afero.Afero{Fs: afero.NewMemMapFs()}
-			configPath := "/absolute/path/.config/osdctl"
-			tokenPath := "/absolute/path/.vault-token"
-
-			err := afs.WriteFile(configPath, []byte("config"), 0644)
-			Expect(err).To(BeNil())
-			err = afs.WriteFile(tokenPath, []byte("token"), 0644)
-			Expect(err).To(BeNil())
-
-			f := Feature{
-				afs: &afs,
-				config: &config{
-					Enabled:            true,
-					ConfigFile:         configPath,
-					TokenFile:          tokenPath,
-					ConfigMountOptions: "ro",
-					TokenMountOptions:  "rw",
-				},
-				userHasConfig: true,
-			}
-
-			opts, err := f.Initialize()
-			Expect(err).To(BeNil())
-			Expect(opts.Mounts).To(HaveLen(2))
-			Expect(opts.Mounts[0].Source).To(Equal(configPath))
-			Expect(opts.Mounts[0].Destination).To(Equal("/root/.config/osdctl"))
-			Expect(opts.Mounts[0].MountOptions).To(Equal("ro"))
-			Expect(opts.Mounts[1].Source).To(Equal(tokenPath))
-			Expect(opts.Mounts[1].Destination).To(Equal("/root/.vault-token"))
-			Expect(opts.Mounts[1].MountOptions).To(Equal("rw"))
-		})
-
-		It("Returns OptionSet with only config mount when token file does not exist", func() {
+		It("Returns OptionSet with only config mount (token mount is deprecated)", func() {
 			afs := afero.Afero{Fs: afero.NewMemMapFs()}
 			configPath := "/absolute/path/.config/osdctl"
 
@@ -227,7 +194,7 @@ var _ = Describe("Pkg/Features/Osdctl/Osdctl", func() {
 				config: &config{
 					Enabled:            true,
 					ConfigFile:         configPath,
-					TokenFile:          "/nonexistent/.vault-token",
+					TokenFile:          vaultTokenFile,
 					ConfigMountOptions: "ro",
 					TokenMountOptions:  "rw",
 				},
@@ -239,6 +206,7 @@ var _ = Describe("Pkg/Features/Osdctl/Osdctl", func() {
 			Expect(opts.Mounts).To(HaveLen(1))
 			Expect(opts.Mounts[0].Source).To(Equal(configPath))
 			Expect(opts.Mounts[0].Destination).To(Equal("/root/.config/osdctl"))
+			Expect(opts.Mounts[0].MountOptions).To(Equal("ro"))
 		})
 
 		It("Finds config file in HOME directory", func() {
@@ -311,14 +279,11 @@ var _ = Describe("Pkg/Features/Osdctl/Osdctl", func() {
 			Expect(f.criticalError).To(BeTrue())
 		})
 
-		It("Uses custom mount options", func() {
+		It("Uses custom mount options for config", func() {
 			afs := afero.Afero{Fs: afero.NewMemMapFs()}
 			configPath := "/test/.config/osdctl"
-			tokenPath := "/test/.vault-token"
 
 			err := afs.WriteFile(configPath, []byte("config"), 0644)
-			Expect(err).To(BeNil())
-			err = afs.WriteFile(tokenPath, []byte("token"), 0644)
 			Expect(err).To(BeNil())
 
 			f := Feature{
@@ -326,7 +291,7 @@ var _ = Describe("Pkg/Features/Osdctl/Osdctl", func() {
 				config: &config{
 					Enabled:            true,
 					ConfigFile:         configPath,
-					TokenFile:          tokenPath,
+					TokenFile:          vaultTokenFile,
 					ConfigMountOptions: "rw",
 					TokenMountOptions:  "ro",
 				},
@@ -335,8 +300,8 @@ var _ = Describe("Pkg/Features/Osdctl/Osdctl", func() {
 
 			opts, err := f.Initialize()
 			Expect(err).To(BeNil())
+			Expect(opts.Mounts).To(HaveLen(1))
 			Expect(opts.Mounts[0].MountOptions).To(Equal("rw"))
-			Expect(opts.Mounts[1].MountOptions).To(Equal("ro"))
 		})
 
 		It("Uses custom config file path when specified", func() {

--- a/pkg/features/ports/ports.go
+++ b/pkg/features/ports/ports.go
@@ -17,6 +17,9 @@ const (
 	portLookupTemplate = `{{(index (index .NetworkSettings.Ports "%d/tcp") 0).HostPort}}`
 
 	defaultConsolePort = 9999
+	defaultVaultPort   = 8250
+
+	vaultCallbackPortFile = "/tmp/vault_callback_port"
 )
 
 // Any internal config needed for the setup of the feature
@@ -24,6 +27,7 @@ type config struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	Console portConfig `mapstructure:"console"`
+	Vault   portConfig `mapstructure:"vault"`
 }
 
 type portConfig struct {
@@ -40,6 +44,10 @@ func newConfigWithDefaults() *config {
 	cfg.Console = portConfig{
 		Enabled: true,
 		Port:    defaultConsolePort,
+	}
+	cfg.Vault = portConfig{
+		Enabled: true,
+		Port:    defaultVaultPort,
 	}
 	return &cfg
 }
@@ -121,6 +129,7 @@ func (f *Feature) Initialize() (features.OptionSet, error) {
 
 	ports := map[string]int{}
 	ports["console"] = f.config.Console.Port
+	ports["vault"] = f.config.Vault.Port
 
 	opts.RegisterPortMap(ports)
 
@@ -140,6 +149,25 @@ func (f *Feature) Initialize() (features.OptionSet, error) {
 
 		o.RegisterBlockingPostStartCmd(portMapCmd)
 		log.Debugf("Console port blocking command registered: '%s'", strings.Join(portMapCmd, " "))
+		return nil
+	})
+
+	opts.RegisterPostStartExecHook(func(o features.ContainerRuntime) error {
+		vaultPortLookup := fmt.Sprintf(portLookupTemplate, f.config.Vault.Port)
+		log.Debugf("Inspect for vault OIDC callback port")
+		vaultPort, err := o.Inspect(vaultPortLookup)
+		if err != nil {
+			return err
+		}
+
+		portMapCmd := []string{
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf("echo \"%v\" > %s", vaultPort, vaultCallbackPortFile),
+		}
+
+		o.RegisterBlockingPostStartCmd(portMapCmd)
+		log.Debugf("Vault callback port blocking command registered: '%s'", strings.Join(portMapCmd, " "))
 		return nil
 	})
 

--- a/pkg/features/ports/ports.go
+++ b/pkg/features/ports/ports.go
@@ -129,7 +129,9 @@ func (f *Feature) Initialize() (features.OptionSet, error) {
 
 	ports := map[string]int{}
 	ports["console"] = f.config.Console.Port
-	ports["vault"] = f.config.Vault.Port
+	if f.config.Vault.Enabled {
+		ports["vault"] = f.config.Vault.Port
+	}
 
 	opts.RegisterPortMap(ports)
 
@@ -152,24 +154,26 @@ func (f *Feature) Initialize() (features.OptionSet, error) {
 		return nil
 	})
 
-	opts.RegisterPostStartExecHook(func(o features.ContainerRuntime) error {
-		vaultPortLookup := fmt.Sprintf(portLookupTemplate, f.config.Vault.Port)
-		log.Debugf("Inspect for vault OIDC callback port")
-		vaultPort, err := o.Inspect(vaultPortLookup)
-		if err != nil {
-			return err
-		}
+	if f.config.Vault.Enabled {
+		opts.RegisterPostStartExecHook(func(o features.ContainerRuntime) error {
+			vaultPortLookup := fmt.Sprintf(portLookupTemplate, f.config.Vault.Port)
+			log.Debugf("Inspect for vault OIDC callback port")
+			vaultPort, err := o.Inspect(vaultPortLookup)
+			if err != nil {
+				return err
+			}
 
-		portMapCmd := []string{
-			"/bin/bash",
-			"-c",
-			fmt.Sprintf("echo \"%v\" > %s", vaultPort, vaultCallbackPortFile),
-		}
+			portMapCmd := []string{
+				"/bin/bash",
+				"-c",
+				fmt.Sprintf("echo \"%v\" > %s", vaultPort, vaultCallbackPortFile),
+			}
 
-		o.RegisterBlockingPostStartCmd(portMapCmd)
-		log.Debugf("Vault callback port blocking command registered: '%s'", strings.Join(portMapCmd, " "))
-		return nil
-	})
+			o.RegisterBlockingPostStartCmd(portMapCmd)
+			log.Debugf("Vault callback port blocking command registered: '%s'", strings.Join(portMapCmd, " "))
+			return nil
+		})
+	}
 
 	return opts, nil
 }

--- a/pkg/features/ports/ports_test.go
+++ b/pkg/features/ports/ports_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 			Expect(opts.PostStartExecHooks).To(HaveLen(2))
 		})
 
-		It("Registers port map even with console and vault disabled", func() {
+		It("Registers only console port when vault is disabled", func() {
 			f := Feature{
 				config: &config{
 					Enabled: true,
@@ -309,9 +309,10 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 
 			opts, err := f.Initialize()
 			Expect(err).To(BeNil())
-			Expect(opts.PortMap).To(HaveLen(2))
+			Expect(opts.PortMap).To(HaveLen(1))
 			Expect(opts.PortMap["console"]).To(Equal(defaultConsolePort))
-			Expect(opts.PortMap["vault"]).To(Equal(defaultVaultPort))
+			Expect(opts.PortMap).ToNot(HaveKey("vault"))
+			Expect(opts.PostStartExecHooks).To(HaveLen(1))
 		})
 	})
 

--- a/pkg/features/ports/ports_test.go
+++ b/pkg/features/ports/ports_test.go
@@ -20,6 +20,8 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 			Expect(cfg.Enabled).To(BeTrue())
 			Expect(cfg.Console.Enabled).To(BeTrue())
 			Expect(cfg.Console.Port).To(Equal(defaultConsolePort))
+			Expect(cfg.Vault.Enabled).To(BeTrue())
+			Expect(cfg.Vault.Port).To(Equal(defaultVaultPort))
 		})
 	})
 
@@ -67,6 +69,8 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 			Expect(f.config.Enabled).To(BeTrue())
 			Expect(f.config.Console.Enabled).To(BeTrue())
 			Expect(f.config.Console.Port).To(Equal(defaultConsolePort))
+			Expect(f.config.Vault.Enabled).To(BeTrue())
+			Expect(f.config.Vault.Port).To(Equal(defaultVaultPort))
 		})
 
 		It("Overwrites defaults with viper config", func() {
@@ -75,6 +79,10 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 				"console": map[string]any{
 					"enabled": false,
 					"port":    8888,
+				},
+				"vault": map[string]any{
+					"enabled": false,
+					"port":    9250,
 				},
 			})
 			f := Feature{}
@@ -85,6 +93,8 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 			Expect(f.config.Enabled).To(BeFalse())
 			Expect(f.config.Console.Enabled).To(BeFalse())
 			Expect(f.config.Console.Port).To(Equal(8888))
+			Expect(f.config.Vault.Enabled).To(BeFalse())
+			Expect(f.config.Vault.Port).To(Equal(9250))
 		})
 
 		It("Overwrites only console port in viper config", func() {
@@ -192,7 +202,7 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 	})
 
 	Context("Tests Feature.Initialize()", func() {
-		It("Registers port map with default console port", func() {
+		It("Registers port map with default console and vault ports", func() {
 			f := Feature{
 				config: &config{
 					Enabled: true,
@@ -200,14 +210,20 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 						Enabled: true,
 						Port:    defaultConsolePort,
 					},
+					Vault: portConfig{
+						Enabled: true,
+						Port:    defaultVaultPort,
+					},
 				},
 			}
 
 			opts, err := f.Initialize()
 			Expect(err).To(BeNil())
-			Expect(opts.PortMap).To(HaveLen(1))
+			Expect(opts.PortMap).To(HaveLen(2))
 			Expect(opts.PortMap).To(HaveKey("console"))
 			Expect(opts.PortMap["console"]).To(Equal(defaultConsolePort))
+			Expect(opts.PortMap).To(HaveKey("vault"))
+			Expect(opts.PortMap["vault"]).To(Equal(defaultVaultPort))
 		})
 
 		It("Registers port map with custom console port", func() {
@@ -219,17 +235,22 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 						Enabled: true,
 						Port:    customPort,
 					},
+					Vault: portConfig{
+						Enabled: true,
+						Port:    defaultVaultPort,
+					},
 				},
 			}
 
 			opts, err := f.Initialize()
 			Expect(err).To(BeNil())
-			Expect(opts.PortMap).To(HaveLen(1))
+			Expect(opts.PortMap).To(HaveLen(2))
 			Expect(opts.PortMap).To(HaveKey("console"))
 			Expect(opts.PortMap["console"]).To(Equal(customPort))
 		})
 
-		It("Registers PostStartExecHook", func() {
+		It("Registers port map with custom vault port", func() {
+			customPort := 9250
 			f := Feature{
 				config: &config{
 					Enabled: true,
@@ -237,15 +258,41 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 						Enabled: true,
 						Port:    defaultConsolePort,
 					},
+					Vault: portConfig{
+						Enabled: true,
+						Port:    customPort,
+					},
 				},
 			}
 
 			opts, err := f.Initialize()
 			Expect(err).To(BeNil())
-			Expect(opts.PostStartExecHooks).To(HaveLen(1))
+			Expect(opts.PortMap).To(HaveLen(2))
+			Expect(opts.PortMap).To(HaveKey("vault"))
+			Expect(opts.PortMap["vault"]).To(Equal(customPort))
 		})
 
-		It("Registers port map even with console disabled", func() {
+		It("Registers PostStartExecHooks for console and vault", func() {
+			f := Feature{
+				config: &config{
+					Enabled: true,
+					Console: portConfig{
+						Enabled: true,
+						Port:    defaultConsolePort,
+					},
+					Vault: portConfig{
+						Enabled: true,
+						Port:    defaultVaultPort,
+					},
+				},
+			}
+
+			opts, err := f.Initialize()
+			Expect(err).To(BeNil())
+			Expect(opts.PostStartExecHooks).To(HaveLen(2))
+		})
+
+		It("Registers port map even with console and vault disabled", func() {
 			f := Feature{
 				config: &config{
 					Enabled: true,
@@ -253,15 +300,18 @@ var _ = Describe("Pkg/Features/Ports/Ports", func() {
 						Enabled: false,
 						Port:    defaultConsolePort,
 					},
+					Vault: portConfig{
+						Enabled: false,
+						Port:    defaultVaultPort,
+					},
 				},
 			}
 
 			opts, err := f.Initialize()
 			Expect(err).To(BeNil())
-			// Port is still registered, even if console is disabled
-			// The enabled flag might be used elsewhere
-			Expect(opts.PortMap).To(HaveLen(1))
+			Expect(opts.PortMap).To(HaveLen(2))
 			Expect(opts.PortMap["console"]).To(Equal(defaultConsolePort))
+			Expect(opts.PortMap["vault"]).To(Equal(defaultVaultPort))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Add dynamic port mapping for vault OIDC authentication (port 8250) to the ports feature, enabling multiple ocm-container instances to run simultaneously without port conflicts
- Deprecate single-file `.vault-token` bind mount in the osdctl feature, which broke vault's atomic `rename()` during OIDC re-authentication inside containers
- Write dynamically-assigned host port to `/tmp/vault_callback_port` for osdctl to discover at runtime

## Problem

When `osdctl rhobs logs` runs inside an ocm-container, it triggers `vault login -method=oidc` which starts an OIDC callback listener on port 8250. The previous approach used `launch-opts: "-p 8250:8250"` to forward this port 1:1, meaning only one container could hold it at a time. Additionally, the single-file bind mount of `~/.vault-token` broke vault's atomic rename during re-authentication.

## Solution

Leverage the existing ports feature's dynamic allocation (`--publish=127.0.0.1::8250`) so each container gets a random available host port mapped to container port 8250. A post-start hook discovers the assigned host port and writes it to `/tmp/vault_callback_port`, which the companion osdctl change reads to pass as `callbackport` to `vault login -method=oidc`.

## Companion PR

- osdctl: https://github.com/openshift/osdctl/pull/910

## Jira

[ROSAENG-39830](https://redhat.atlassian.net/browse/ROSAENG-39830)

## Test plan

- [x] Unit tests pass: `go test -p 1 ./pkg/features/ports/ ./pkg/features/osdctl/`
- [x] Launch 2+ ocm-containers simultaneously — no port conflicts
- [x] Verify `/tmp/vault_callback_port` contains the dynamically assigned host port
- [x] End-to-end with companion osdctl PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vault OIDC callback port configuration enabling dynamic port 8250 mapping between host and container.

* **Deprecations**
  * Token file mounting configuration (token_file and token_mount_options) deprecated in favor of in-process token management.

* **Documentation**
  * Updated documentation for new Vault callback port configuration and osdctl feature token handling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->