### PR TITLE
Add user notification when OCM browser auth is triggered

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -343,10 +343,12 @@ func ensureArmed(ocmConfig *config.Config) error {
 
 	if !armed {
 		log.Debugf("not logged into OCM: %s", reason)
+		fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
 		token, err = auth.InitiateAuthCode(ocmContainerClientId)
 		if err != nil {
 			return fmt.Errorf("error initiating auth code: %s", err)
 		}
+		fmt.Fprintln(os.Stderr, "OCM authentication successful.")
 	} else {
 		log.Debug("already logged into OCM")
 		token = ocmConfig.AccessToken


### PR DESCRIPTION
## Summary
- Add stderr messages before and after `InitiateAuthCode()` in `ensureArmed()`
- When OCM tokens are expired and browser auth is initiated, users now see:
  - `OCM tokens expired — opening browser for authentication...` before the browser opens
  - `OCM authentication successful.` after auth completes
- Previously the app appeared to hang with no feedback during browser OAuth

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] Messages use stderr so they're visible regardless of log level
- [x] No change to existing behavior when tokens are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication experience by displaying status messages during token expiration and browser-based login, including confirmation of successful authentication initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->