### PR TITLE
Re-enable yq; bump backplane-tools to v1.4.0; remove servicelogger

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ COPY utils/dockerfile_assets/github_dl.py /usr/local/bin/github_dl
 FROM tools-base as backplane-tools
 ARG OUTPUT_DIR="/opt"
 
-ARG BACKPLANE_TOOLS_VERSION="tags/v1.2.0"
+ARG BACKPLANE_TOOLS_VERSION="tags/v1.4.0"
 ENV BACKPLANE_TOOLS_URL_SLUG="openshift/backplane-tools"
 ENV BACKPLANE_TOOLS_URL="https://api.github.com/repos/${BACKPLANE_TOOLS_URL_SLUG}/releases/${BACKPLANE_TOOLS_VERSION}"
 ENV BACKPLANE_TOOLS_CHECKSUM_FILE="checksums.txt"
@@ -125,12 +125,9 @@ RUN osdctl completion bash --skip-version-check > /etc/bash_completion.d/osdctl
 COPY --from=backplane-tools /${OUTPUT_DIR}/rosa          ${BIN_DIR}
 RUN rosa completion bash > /etc/bash_completion.d/rosa
 
-COPY --from=backplane-tools /${OUTPUT_DIR}/servicelogger ${BIN_DIR}
-RUN servicelogger completion bash > /etc/bash_completion.d/servicelogger
 
-## Comment this out for everyone until SREP-1737 is completed
-# COPY --from=backplane-tools /${OUTPUT_DIR}/yq            ${BIN_DIR}
-# RUN yq --version
+COPY --from=backplane-tools /${OUTPUT_DIR}/yq            ${BIN_DIR}
+RUN yq --version
 
 ENV IO_OPENSHIFT_MANAGED_NAME="ocm-container"
 ENV IO_OPENSHIFT_MANAGED_COMPONENT="minimal"

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -53,7 +53,7 @@ func IsRunningInOcmContainer() bool {
 //
 // Possible return values:
 //   - "micro": ocm-container-micro variant (minimal tools: ocm, ocm-backplane, oc)
-//   - "minimal": ocm-container-minimal variant (adds AWS CLI, rosa, osdctl, servicelogger)
+//   - "minimal": ocm-container-minimal variant (adds AWS CLI, rosa, osdctl, yq)
 //   - "full": ocm-container variant (full toolset including omc, jira-cli, oc-nodepp, vault, and more)
 //   - "": not running in ocm-container
 //


### PR DESCRIPTION
## Summary

- Re-enables `yq` in the minimal container image now that [SREP-1737](https://redhat.atlassian.net/browse/SREP-1737) is complete
- Bumps `backplane-tools` from `v1.2.0` to `v1.4.0`, which includes the arm64 yq fix and is required for yq to be present in the build
- Removes `servicelogger` COPY/RUN lines, as it was dropped from backplane-tools in v1.4.0

## Test plan

- [x] `make test` — all Go unit tests pass
- [x] `make build-image-arm64` — all three image variants (micro, minimal, full) build successfully for arm64, including the yq COPY and `yq --version` smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated backplane-tools to v1.4.0.
  * Modified container image to include and enable the yq tool, removing the previous servicelogger binary.

* **Documentation**
  * Clarified documentation to note the minimal container variant now includes yq instead of the servicelogger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->