### PR TITLE
Remove 'iamkirkbater' from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,14 @@
 reviewers:
 - chamalabey
 - clcollins
-- iamkirkbater
 - smarthall
 - tkong-redhat
 - samanthajayasinghe
 approvers:
 - chamalabey
 - clcollins
-- iamkirkbater
 - smarthall
 - tkong-redhat
 - samanthajayasinghe
 maintainers:
 - clcollins
-- iamkirkbater


### PR DESCRIPTION
Removed 'iamkirkbater' from reviewers, approvers, and maintainers.

Of all of the Owners file PR updates - this one is probably the one that was the hardest to make.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ownership list to reflect current reviewers, approvers, and maintainers.
  * Removed a no-longer-listed contributor and kept the remaining names in the expected order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->