### PR TITLE
Remove unused nodejs, nodejs-nodemon, and npm packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -152,9 +152,6 @@ RUN dnf --assumeyes --nodocs install \
       golang \
       krb5-workstation \
       make \
-      nodejs \
-      nodejs-nodemon \
-      npm \
       openssl \
       podman \
       procps-ng \


### PR DESCRIPTION
## Summary

- Remove `nodejs`, `nodejs-nodemon`, and `npm` from the `dnf install` in the full image
- These packages are not used by anything in ocm-container — no `npm install` is ever run, no scripts reference node, and `oc-nodepp` is a Go binary (the "node" in its name refers to Kubernetes nodes, not Node.js)
- Reduces image size and eliminates unnecessary attack surface from transitive JavaScript dependencies

## REF

- [ROSAENG-60540](https://redhat.atlassian.net/browse/ROSAENG-60540)
- [ROSAENG-60947](https://redhat.atlassian.net/browse/ROSAENG-60947)
- [ROSAENG-60064](https://redhat.atlassian.net/browse/ROSAENG-60064)
- [ROSAENG-59839](https://redhat.atlassian.net/browse/ROSAENG-59839)
- [ROSAENG-59838](https://redhat.atlassian.net/browse/ROSAENG-59838)
- [ROSAENG-59836](https://redhat.atlassian.net/browse/ROSAENG-59836)
- [ROSAENG-59835](https://redhat.atlassian.net/browse/ROSAENG-59835)
- [ROSAENG-59834](https://redhat.atlassian.net/browse/ROSAENG-59834)
- [ROSAENG-59833](https://redhat.atlassian.net/browse/ROSAENG-59833)
- [ROSAENG-59832](https://redhat.atlassian.net/browse/ROSAENG-59832)
- [ROSAENG-59427](https://redhat.atlassian.net/browse/ROSAENG-59427)

## Test plan

- [ ] Verify full container image builds successfully without nodejs/npm
- [ ] Verify `oc-nodepp` still works (Go binary, no Node.js dependency)
- [ ] Verify no scripts in `utils/` depend on node or npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary Node.js-related packages from the build image, resulting in a leaner container and a smaller install footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->