### PR TITLE
fix: update IMAGE_REPOSITORY to current Konflux registry path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ AUTHFILE_FLAG         :=
 endif
 
 IMAGE_REGISTRY        ?= quay.io
-IMAGE_REPOSITORY      ?= app-sre
+IMAGE_REPOSITORY      ?= redhat-services-prod/openshift
 IMAGE_NAME            ?= $(PROJECT_NAME)
 IMAGE_URI             := $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)
 TAG                   ?= latest


### PR DESCRIPTION
## Summary

- Update `IMAGE_REPOSITORY` default in the Makefile from the legacy `app-sre` path to `redhat-services-prod/openshift`
- Images are built and pushed nightly by Konflux to `quay.io/redhat-services-prod/openshift/ocm-container:latest`
- The Go binary already references the correct path (`cmd/root.go` line 236), and the README is also correct — only the Makefile default was stale

## Test plan

- [ ] `make check-env` shows the correct image URI: `quay.io/redhat-services-prod/openshift`
- [ ] Local builds with overridden `IMAGE_REPOSITORY` still work (the `?=` operator preserves override behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image repository used for image tagging, builds, pushes, and manifest operations.
  * Container images now target the `redhat-services-prod/openshift` repository by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->