### PR TITLE
Change default JIRA_AUTH_TYPE from bearer to basic

### DIFF
--- a/docs/features/jira.md
+++ b/docs/features/jira.md
@@ -3,7 +3,7 @@
 This assumes that the JIRA CLI tool is already set up and working outside of the container.
 
 * No additional configuration required if the configuration file is in the standard location ($HOME/.jira/.config.yml)
-* Additionally checks `JIRA_API_TOKEN`, optional `JIRA_AUTH_TYPE` (defaults to `bearer` when token is set), and optional `JIRA_EMAIL` (passed through when set).
+* Additionally checks `JIRA_API_TOKEN`, optional `JIRA_AUTH_TYPE` (defaults to `basic` when token is set), and optional `JIRA_EMAIL` (passed through when set).
 * Can be explicitly disabled with the `--no-jira` flag or with the following yaml in the ocm-container config file:
 ```
 features:

--- a/docs/occ-migration.md
+++ b/docs/occ-migration.md
@@ -123,7 +123,7 @@ To disable this functionality or change the config directory, the following conf
 
 #### JIRA
 By default, the JIRA integration checks `JIRA_API_TOKEN`, `JIRA_AUTH_TYPE`, and `JIRA_EMAIL`, and also attempts to mount `~/.jira/.config.yml`.
-If `JIRA_API_TOKEN` is set, it is passed through; if `JIRA_AUTH_TYPE` is missing, it defaults to `bearer`.
+If `JIRA_API_TOKEN` is set, it is passed through; if `JIRA_AUTH_TYPE` is missing, it defaults to `basic`.
 `JIRA_EMAIL` is passed through independently when set (for tools such as `osdctl`), regardless of token presence.
 If the config file is missing, env var passthrough behavior is unchanged.
 

--- a/pkg/features/jira/jira.go
+++ b/pkg/features/jira/jira.go
@@ -20,7 +20,7 @@ const (
 	jiraEnvTokenKey           = "JIRA_API_TOKEN" //nolint:gosec // env var name, not a credential
 	jiraEnvEmailKey           = "JIRA_EMAIL"
 	jiraAuthTypeKey           = "JIRA_AUTH_TYPE"
-	defaultAuthType           = "bearer"
+	defaultAuthType           = "basic"
 	defaultConfigFileLocation = ".config/.jira/.config.yml"
 
 	jiraConfigFileDest = "/root/.config/.jira/.config.yml"

--- a/pkg/features/jira/jira_test.go
+++ b/pkg/features/jira/jira_test.go
@@ -274,6 +274,35 @@ var _ = Describe("Pkg/Features/Jira/Jira", func() {
 			Expect(authTypeVal).To(Equal("basic"))
 		})
 
+		It("Preserves explicit bearer auth type override", func() {
+			os.Setenv("JIRA_API_TOKEN", "test-token")
+			os.Setenv("JIRA_AUTH_TYPE", "bearer")
+			afs := afero.Afero{Fs: afero.NewMemMapFs()}
+			configFile := "/path/to/.config/.jira/.config.yml"
+			err := afs.WriteFile(configFile, []byte("{}"), 0644)
+			Expect(err).To(BeNil())
+
+			f := Feature{
+				afs: &afs,
+				config: &config{
+					Enabled:   true,
+					FilePath:  configFile,
+					MountOpts: "ro",
+				},
+			}
+
+			opts, err := f.Initialize()
+			Expect(err).To(BeNil())
+			findAuthType := false
+			for _, env := range opts.Envs {
+				if env.Key == "JIRA_AUTH_TYPE" {
+					findAuthType = true
+					Expect(env.Value).To(BeEmpty())
+				}
+			}
+			Expect(findAuthType).To(BeTrue())
+		})
+
 		It("Adds JIRA_AUTH_TYPE env var when both token and auth type are set", func() {
 			os.Setenv("JIRA_API_TOKEN", "test-token")
 			os.Setenv("JIRA_AUTH_TYPE", "basic")

--- a/pkg/features/jira/jira_test.go
+++ b/pkg/features/jira/jira_test.go
@@ -271,7 +271,7 @@ var _ = Describe("Pkg/Features/Jira/Jira", func() {
 
 			Expect(findAPIToken).To(Equal(true))
 			Expect(findAuthType).To(Equal(true))
-			Expect(authTypeVal).To(Equal("bearer"))
+			Expect(authTypeVal).To(Equal("basic"))
 		})
 
 		It("Adds JIRA_AUTH_TYPE env var when both token and auth type are set", func() {


### PR DESCRIPTION
## Summary
- Changes the default `JIRA_AUTH_TYPE` from `bearer` to `basic` to match Atlassian Cloud (redhat.atlassian.net) requirements
- Updates corresponding test expectation
- Users on self-hosted Jira Server who need bearer auth can still override via the `JIRA_AUTH_TYPE` environment variable

## Test plan
- [x] Jira feature unit tests pass (39/39)
- [ ] Verify `jira-cli` works with basic auth inside ocm-container against `redhat.atlassian.net`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JIRA authentication defaults so that when no authentication type is specified, `JIRA_AUTH_TYPE` now defaults to `basic` (instead of `bearer`).
  * Improved consistency between JIRA API token authentication behavior, tests, and related Jira CLI/migration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->