### PR TITLE
Pin epel-release to Koji build for multi-arch consistency

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -135,10 +135,6 @@ ENV IO_OPENSHIFT_MANAGED_COMPONENT="minimal"
 ### DNF Install other tools on top of Minimal
 FROM ocm-container-minimal as dnf-install
 
-# Add epel repos - dynamically detect RHEL version
-RUN RHEL_VERSION=$(rpm -E %{rhel}) && \
-    rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-${RHEL_VERSION} && \
-    rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${RHEL_VERSION}.noarch.rpm
 
 # Install packages
 # These packages will end up in the final image


### PR DESCRIPTION
## Summary
- Pin `epel-release` RPM to a specific Koji build artifact instead of using the floating `epel-release-latest-10` symlink from `dl.fedoraproject.org`
- Prevents Enterprise Contract `rpm_packages.unique_version` failures caused by CDN mirror skew during concurrent multi-arch builds
- Uses a build `ARG` so future version bumps are a one-line change

## Background
The `epel-release-latest-10.noarch.rpm` symlink on `dl.fedoraproject.org` can resolve to different versions depending on CDN mirror state (`10-8.el10_2` vs `10-8.el10_3`). When x86_64 and arm64 builds run concurrently, they can install different versions of the same noarch RPM, causing the EC `rpm_packages.unique_version` rule to fail.

Koji (`kojipkgs.fedoraproject.org`) serves individual build artifacts directly and is not subject to mirror propagation delays. The RPM is GPG-signed with the EPEL key regardless of download source.

## Test plan
- [ ] Multi-arch container build succeeds for all three variants (micro, minimal, full)
- [ ] Enterprise Contract `rpm_packages.unique_version` check passes
- [ ] EPEL packages (e.g., `fzf`) still install correctly in the full image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container build to install a pinned EPEL release package instead of a dynamically selected “latest” release.
  * Improved build consistency and predictability by avoiding runtime detection of the platform version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->