### PR TITLE
fix: update goreleaser archives.format to archives.formats

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,8 @@ builds:
     ldflags:
       - -X github.com/openshift/ocm-container/pkg/utils.Version={{.Version}}
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_


### PR DESCRIPTION
## Summary
- Updates `.goreleaser.yaml` to use `archives.formats` (list) instead of the deprecated `archives.format` (string), resolving a GoReleaser v2 deprecation warning that blocks `goreleaser check` validation.

## Test plan
- [x] `goreleaser check --config .goreleaser.yaml` passes
- [x] `goreleaser build --clean --snapshot --single-target=true` succeeds
- [x] v1.0.1 draft release built successfully with this fix applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release archive configuration to use the current format specification.
  * Release archives continue to be provided in tar.gz format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->