### PR TITLE
Add user-facing status messages for cluster lookup and OCM auth

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -346,7 +346,7 @@ func ensureArmed(ocmConfig *config.Config) error {
 
 	if !armed {
 		log.Debugf("not logged into OCM: %s", reason)
-		fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
+		fmt.Fprintln(os.Stderr, "Please complete OCM browser authentication...")
 		token, err = auth.InitiateAuthCode(ocmContainerClientId)
 		if err != nil {
 			return fmt.Errorf("error initiating auth code: %s", err)

--- a/pkg/ocmcontainer/ocmcontainer.go
+++ b/pkg/ocmcontainer/ocmcontainer.go
@@ -118,6 +118,7 @@ func New(cmd *cobra.Command, args []string) (*Runtime, error) {
 	if cluster != "" {
 		conn := ocm.GetClient()
 		// check if cluster exists to fail fast
+		fmt.Fprintln(os.Stderr, "Looking up cluster: "+cluster+"...")
 		_, err := ocm.GetCluster(conn, cluster)
 		if err != nil {
 			return o, fmt.Errorf("%v - using ocm-url %s", err, conn.URL())


### PR DESCRIPTION
## Summary
- Add a "Looking up cluster: <id>..." message to stderr before the cluster lookup API call, so the terminal doesn't appear hung while OCM resolves the cluster
- Update the browser auth message to "Please complete OCM browser authentication..." for clarity when tokens are expired and the browser auth flow starts

## Test plan
- [ ] Run `ocm-container -C <cluster-id>` and verify "Looking up cluster: <cluster-id>..." appears before the lookup
- [ ] With expired OCM tokens, run `ocm-container` and verify "Please complete OCM browser authentication..." appears
- [ ] Verify all unit tests pass with `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)