### PR TITLE
rm golang image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -145,7 +145,6 @@ RUN dnf --assumeyes --nodocs install \
       findutils \
       fuse-overlayfs \
       git \
-      golang \
       krb5-workstation \
       make \
       openssl \

--- a/Containerfile
+++ b/Containerfile
@@ -287,9 +287,9 @@ RUN /usr/local/aws-cli/aws ssm help
 RUN rm ${BIN_DIR}/platform_convert
 
 # install rh-aws-saml-login
-RUN dnf install -y python3.14-devel krb5-devel
+RUN dnf install -y python3.14-devel krb5-devel gcc
 RUN python3.14 -m pip install rh-aws-saml-login
-RUN dnf remove -y python3.14-devel krb5-devel
+RUN dnf remove -y python3.14-devel krb5-devel gcc
 
 # Setup bashrc.d directory
 # Files with a ".bashrc" extension are sourced on login

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,8 @@
-ARG BASE_IMAGE=registry.access.redhat.com/ubi10/ubi:10.2-1787187823
+# Ensure UBI base image is not the full, tagged sub-hash (eg 10.2-1787187823)
+# The y-stream tag will always pull the latest hash, and tagging to a specific 
+# SHA does not make sense for a CLI tool built nightly the way it does for fleet
+# operators that require more orchestration.
+ARG BASE_IMAGE=registry.access.redhat.com/ubi10/ubi:10.2
 FROM ${BASE_IMAGE} as tools-base
 ARG OUTPUT_DIR="/opt"
 

--- a/Containerfile
+++ b/Containerfile
@@ -291,9 +291,11 @@ RUN /usr/local/aws-cli/aws ssm help
 RUN rm ${BIN_DIR}/platform_convert
 
 # install rh-aws-saml-login
-RUN dnf install -y python3.14-devel krb5-devel gcc
-RUN python3.14 -m pip install rh-aws-saml-login
-RUN dnf remove -y python3.14-devel krb5-devel gcc
+RUN dnf install -y --nodocs python3.14-devel krb5-devel gcc \
+    && python3.14 -m pip install --no-cache-dir rh-aws-saml-login \
+    && dnf remove -y python3.14-devel krb5-devel gcc \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf /var/cache/yum
 
 # Setup bashrc.d directory
 # Files with a ".bashrc" extension are sourced on login

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ GIT_REVISION          := $(shell git rev-parse --short=7 HEAD)
 
 BUILD_ARGS            ?=
 CACHE                 ?= --no-cache
+PULL                  ?= --pull
 
 # Overrides the base image labels, and adds additional metadata
 PROJECT_LABELS := \
@@ -199,7 +200,7 @@ endef
 # Builds the container image for the specified target and architecture
 define build_target
 	@echo "Building image: $(1) for architecture: $(2) with manifest $(IMAGE_URI)/$(1):latest"
-	$(eval BUILD_FLAGS := --target=$(1) --platform=$(2) $(CACHE) $(BUILD_ARGS))
+	$(eval BUILD_FLAGS := --target=$(1) --platform=$(2) $(CACHE) $(PULL) $(BUILD_ARGS))
 	$(eval BUILD_FLAGS += $(if $(GITHUB_BUILD_ARGS),$(GITHUB_BUILD_ARGS)))
 	$(eval BUILD_FLAGS += -f Containerfile)
 	$(eval PROJECT_LABELS += --label "architecture=$(2)")
@@ -215,7 +216,7 @@ endef
 # We also force the platform to linux/[arch] because the ubi containers don't have darwin targets
 define build_local_target
 	@echo "Building local image: $(1) for architecture: $(2) (without manifest)"
-	$(eval BUILD_FLAGS := --target=$(1) --platform=linux/$(2) $(CACHE) $(BUILD_ARGS))
+	$(eval BUILD_FLAGS := --target=$(1) --platform=linux/$(2) $(CACHE) $(PULL) $(BUILD_ARGS))
 	$(eval BUILD_FLAGS += $(if $(GITHUB_BUILD_ARGS),$(GITHUB_BUILD_ARGS)))
 	$(eval BUILD_FLAGS += -f Containerfile)
 	$(eval PROJECT_LABELS += --label "architecture=$(2)")


### PR DESCRIPTION
# Remove golang from full image
    
There's no good reason for the golang RPM to be in the final ocm-container image - the image is not a development tool and this is a waste of space and incurrs false-positive vulnerability scanning findings.
    
Signed-off-by: Christopher Collins <collins.christopher@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container build environment to use the latest rolling base image.
  * Removed the unnecessary Go package from build dependencies.
  * Added GCC temporarily to support installation, then removed it during cleanup to keep the resulting image lean.
  * Container builds now pull the latest base images by default, with an option to customize this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->