### PR TITLE
Default backplane config path failing for Mac

### DIFF
--- a/pkg/features/backplane/backplane.go
+++ b/pkg/features/backplane/backplane.go
@@ -17,7 +17,7 @@ const (
 
 	backplaneConfigDest      = "/root/.config/backplane/config.json"
 	backplaneConfigMountOpts = "rw"
-	defaultBackplaneConfig   = ".config/backplane/config.json"
+	defaultBackplaneConfig   = "$HOME/.config/backplane/config.json"
 )
 
 type config struct {

--- a/pkg/features/gcloud/gcloud.go
+++ b/pkg/features/gcloud/gcloud.go
@@ -16,7 +16,7 @@ const (
 	FeatureFlagName = "no-gcloud"
 	FlagHelpMessage = "Disable GCloud configuration mounting"
 
-	gcloudConfigDir = ".config/gcloud"
+	gcloudConfigDir = "$HOME/.config/gcloud"
 )
 
 type config struct {


### PR DESCRIPTION
Prepending $HOME to the path fix the issue.

Following is the error you see:
```
~ % ocm-container
Error: statfs /.config/backplane/config.json: no such file or directory
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backplane configuration is now loaded from the standard configuration directory in the user’s home folder, improving reliability across working directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->